### PR TITLE
Disable member subnet validation: not used by F5 backed driver anyway

### DIFF
--- a/octavia/api/v2/controllers/member.py
+++ b/octavia/api/v2/controllers/member.py
@@ -148,9 +148,11 @@ class MemberController(base.BaseController):
         validate.ip_not_reserved(member.address)
 
         # Validate member subnet
-        if (member.subnet_id and
-                not validate.subnet_exists(member.subnet_id, context=context)):
-            raise exceptions.NotFound(resource='Subnet', id=member.subnet_id)
+        """ CCloud: disable subnet validation since it's not used by the f5 backend driver and just impose
+            a risk of failure due to failed keystone / neutron calls """
+        #if (member.subnet_id and
+        #        not validate.subnet_exists(member.subnet_id, context=context)):
+        #    raise exceptions.NotFound(resource='Subnet', id=member.subnet_id)
         pool = self.repositories.pool.get(context.session, id=self.pool_id)
         member.project_id, provider = self._get_lb_project_id_provider(
             context.session, pool.load_balancer_id)


### PR DESCRIPTION
Subnet validation implies a synchronous call to keystone and neutron. This adds a significant latency and risk of failures although the F5 backend completely ingores (and doesn't support) specific subnet members.