### PR TITLE
Use OSProfiler WSGI middleware with Jaeger backend

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -1,3 +1,9 @@
+# Any requirements we need for CCloud
+
+# tracing
+osprofiler>=1.4.0 # Apache-2.0
+jaeger-client
+
 raven
 -e git+https://github.com/sapcc/octavia-f5-provider-driver.git#egg=octavia-f5-provider-driver
 git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middleware

--- a/octavia/api/app.py
+++ b/octavia/api/app.py
@@ -112,7 +112,7 @@ def _wrap_app(app):
             )
 
     # OSProfiler tracing middleware
-    if CONF.profiler.enabled and profiler_initializer and profiler_opts and profiler_web:
+    if profiler_initializer and profiler_opts and profiler_web and CONF.profiler.enabled:
         LOG.info("OSProfiler Middleware activated")
         profiler_opts.set_defaults(CONF)
         profiler_initializer.init_from_conf(

--- a/octavia/api/app.py
+++ b/octavia/api/app.py
@@ -40,6 +40,11 @@ CONF = cfg.CONF
 watcher_errors = importutils.try_import('watcher.errors')
 watcher_middleware = importutils.try_import('watcher.watcher')
 
+# OSProfiler tracing
+profiler_initializer = importutils.try_import('osprofiler.initializer')
+profiler_opts = importutils.try_import('osprofiler.opts')
+profiler_web = importutils.try_import('osprofiler.web')
+
 
 def get_pecan_config():
     """Returns the pecan config."""
@@ -105,6 +110,21 @@ def _wrap_app(app):
                 file_name=CONF.watcher.config_file,
                 reason=e
             )
+
+    # OSProfiler tracing middleware
+    if CONF.profiler.enabled and profiler_initializer and profiler_opts and profiler_web:
+        LOG.info("OSProfiler Middleware activated")
+        profiler_opts.set_defaults(CONF)
+        profiler_initializer.init_from_conf(
+            conf=CONF,
+            context={}, # must not be None
+            project="octavia",
+            service="octavia-api",  # The name of the octavia API binary
+            host=CONF.host
+        )
+        profiler_factory = profiler_web.WsgiMiddleware.factory(None, hmac_keys=CONF.profiler.hmac_keys, enabled=True)
+        app = profiler_factory(app)
+
 
     if cfg.CONF.api_settings.auth_strategy == constants.KEYSTONE:
         app = keystone.SkippingAuthProtocol(app, {})

--- a/octavia/network/drivers/neutron/base.py
+++ b/octavia/network/drivers/neutron/base.py
@@ -22,7 +22,7 @@ from octavia.i18n import _
 from octavia.network import base
 from octavia.network import data_models as network_models
 from octavia.network.drivers.neutron import utils
-
+from octavia.network.drivers.neutron.utils import Profiler as profiler
 
 LOG = logging.getLogger(__name__)
 DNS_INT_EXT_ALIAS = 'dns-integration'
@@ -32,6 +32,7 @@ QOS_EXT_ALIAS = 'qos'
 CONF = cfg.CONF
 
 
+@profiler.trace_cls("neutron_api")
 class BaseNeutronDriver(base.AbstractNetworkDriver):
 
     def __init__(self):


### PR DESCRIPTION
Add OSProfiler WSGI middleware to Pecan.
Please review [the Charts PR](https://github.com/sapcc/helm-charts/compare/octavia_tracing?expand=1) first.

We use `custom-requirements.txt` in other projects for CCloud-specific requirements, so I used it here as well.

I am not really sure about the use of the `context` parameter in the invocation of `init_from_conf`. Apparently it's a context supplied in calls to Jaeger backend, and in Cinder it is [a custom Object returned by a `get_admin_context` function](https://github.com/sapcc/cinder/blob/stable/queens-m3/cinder/context.py#L246-L251). I set it to `{}`, [like Keystone does](https://github.com/sapcc/keystone/blob/stable/rocky-m3/keystone/common/profiler.py#L34).