### PR TITLE
Pin jaeger-client to 4.1.0

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -2,7 +2,7 @@
 
 # tracing
 osprofiler>=1.4.0 # Apache-2.0
-jaeger-client
+jaeger-client==4.1.0
 
 raven
 -e git+https://github.com/sapcc/octavia-f5-provider-driver.git#egg=octavia-f5-provider-driver


### PR DESCRIPTION
Jaeger client throws errors a la `Address family not supported by
protocol`. Keystone et al are using 4.1.0, so let's try pinning it.

Not sure if [requirements on branch stable/stein-m3](https://github.com/sapcc/requirements/blob/stable/stein-m3/upper-constraints.txt#L486) takes precedence over this. If so, I'll make a PR there.