### PR TITLE
Disallow TLS option with HTTPS listener and HTTPS pool.

### DIFF
--- a/octavia/api/v2/controllers/base.py
+++ b/octavia/api/v2/controllers/base.py
@@ -313,6 +313,16 @@ class BaseController(pecan.rest.RestController):
                     "authority reference supplied."))
 
     @staticmethod
+    def _validate_tls_option_proto(listener_protocol, pool_protocol,
+                                   pool_tls_opt):
+        if (listener_protocol == constants.PROTOCOL_HTTPS and
+                pool_protocol == constants.PROTOCOL_HTTPS and pool_tls_opt):
+            raise exceptions.InvalidOption(
+                    value='TLS enabled',
+                    option=('%s protocol listener and for %s protocol pool.'
+                            % (listener_protocol, pool_protocol)))
+
+    @staticmethod
     def _validate_protocol(listener_protocol, pool_protocol):
         proto_map = constants.VALID_LISTENER_POOL_PROTOCOL_MAP
         for valid_pool_proto in proto_map[listener_protocol]:
@@ -323,3 +333,5 @@ class BaseController(pecan.rest.RestController):
                        "pool_protocol": pool_protocol,
                        "listener_protocol": listener_protocol}
         raise exceptions.ValidationException(detail=detail)
+
+

--- a/octavia/api/v2/controllers/listener.py
+++ b/octavia/api/v2/controllers/listener.py
@@ -116,6 +116,8 @@ class ListenersController(base.BaseController):
             raise exceptions.NotFound(
                 resource=data_models.Pool._name(), id=pool_id)
         self._validate_protocol(listener_protocol, db_pool.protocol)
+        self._validate_tls_option_proto(listener_protocol, db_pool.protocol,
+                                        db_pool.tls_enabled)
 
     def _has_tls_container_refs(self, listener_dict):
         return (listener_dict.get('tls_certificate_id') or

--- a/octavia/api/v2/controllers/pool.py
+++ b/octavia/api/v2/controllers/pool.py
@@ -210,6 +210,8 @@ class PoolsController(base.BaseController):
 
         if pool.listener_id and listener:
             self._validate_protocol(listener.protocol, pool.protocol)
+            self._validate_tls_option_proto(
+                listener.protocol, pool.protocol, pool.tls_enabled)
 
         if pool.protocol == constants.PROTOCOL_UDP:
             self._validate_pool_request_for_udp(pool)

--- a/octavia/tests/functional/api/v2/test_listener.py
+++ b/octavia/tests/functional/api/v2/test_listener.py
@@ -2499,6 +2499,40 @@ class TestListener(base.BaseAPITest):
         self.get(self.LISTENER_PATH.format(
             listener_id=li.get('id') + "/stats"), status=404)
 
+    def test_invalid_listener_pool_protocol_and_tls_option_post(self):
+        pool = self.create_pool(
+            self.lb_id, constants.PROTOCOL_HTTPS,
+            constants.LB_ALGORITHM_ROUND_ROBIN, tls_enabled=True).get('pool')
+        self.set_object_status(self.lb_repo, self.lb_id)
+        listener = {'protocol': constants.PROTOCOL_HTTPS,
+                    'protocol_port': 80,
+                    'loadbalancer_id': self.lb_id,
+                    'default_pool_id': pool.get('id')}
+        body = self._build_body(listener)
+        expect_error_msg = ("TLS enabled is not a valid option for HTTPS "
+                            "protocol listener and for HTTPS protocol pool.")
+        res = self.post(self.LISTENERS_PATH, body, status=400,
+                        expect_errors=True)
+        self.assertEqual(expect_error_msg, res.json['faultstring'])
+        self.assert_correct_status(lb_id=self.lb_id)
+
+    def test_invalid_listener_pool_protocol_and_tls_option_put(self):
+        pool = self.create_pool(
+            self.lb_id, constants.PROTOCOL_HTTPS,
+            constants.LB_ALGORITHM_ROUND_ROBIN, tls_enabled=True).get('pool')
+        self.set_object_status(self.lb_repo, self.lb_id)
+        listener = self.create_listener(
+            constants.PROTOCOL_HTTPS, 80, self.lb_id).get('listener')
+        expect_error_msg = ("TLS enabled is not a valid option for HTTPS "
+                            "protocol listener and for HTTPS protocol pool.")
+        self.set_object_status(self.lb_repo, self.lb_id)
+        new_listener = {'default_pool_id': pool.get('id')}
+        res = self.put(
+            self.LISTENER_PATH.format(listener_id=listener.get('id')),
+            self._build_body(new_listener), status=400)
+        self.assertEqual(expect_error_msg, res.json['faultstring'])
+        self.assert_correct_status(lb_id=self.lb_id)
+
     @mock.patch('octavia.common.tls_utils.cert_parser.load_certificates_data')
     def test_listener_pool_protocol_map_post(self, mock_cert_data):
         cert = data_models.TLSContainer(certificate='cert')

--- a/octavia/tests/functional/api/v2/test_pool.py
+++ b/octavia/tests/functional/api/v2/test_pool.py
@@ -2398,6 +2398,23 @@ class TestPool(base.BaseAPITest):
                               status=201)
                     self.set_object_status(self.lb_repo, self.lb_id)
 
+    def test_invalid_listener_pool_protocol_and_tls_option_post(self):
+        listener = self.create_listener(
+            constants.PROTOCOL_HTTPS, 8080, self.lb_id).get('listener')
+        self.set_object_status(self.lb_repo, self.lb_id)
+        lb_pool = {
+            'lb_algorithm': constants.LB_ALGORITHM_ROUND_ROBIN,
+            'project_id': self.project_id,
+            'protocol': constants.PROTOCOL_HTTPS,
+            'listener_id': listener.get('id'),
+            'tls_enabled': True}
+        expect_error_msg = ("TLS enabled is not a valid option for HTTPS "
+                            "protocol listener and for HTTPS protocol pool.")
+        res = self.post(self.POOLS_PATH, self._build_body(lb_pool),
+                        status=400, expect_errors=True)
+        self.assertEqual(expect_error_msg, res.json['faultstring'])
+        self.assert_correct_status(lb_id=self.lb_id)
+
     @mock.patch('octavia.common.tls_utils.cert_parser.load_certificates_data')
     def test_invalid_listener_pool_protocol_map(self, mock_cert_data):
         cert = data_models.TLSContainer(certificate='cert')


### PR DESCRIPTION
This PR adds an additional validation for listener and pool protocols to check conflicts with TLS-enabled option. We will return the API 400 error
```
TLS enabled is not a valid option for HTTPS protocol listener and for HTTPS protocol pool.
```
when listener and pool creating with HTTPS protocol and the pool has tls_enabled = true option.

PR contains:
- [x] validate requests POST .../listeners/
- [x] validate requests PUT .../listeners/
- [x] validate requests POST .../pools.
- [x]  functional tests for API v2