### PR TITLE
Add checks to L7 policies API for extended policies.

### DIFF
--- a/octavia/api/v2/controllers/base.py
+++ b/octavia/api/v2/controllers/base.py
@@ -323,3 +323,24 @@ class BaseController(pecan.rest.RestController):
                        "pool_protocol": pool_protocol,
                        "listener_protocol": listener_protocol}
         raise exceptions.ValidationException(detail=detail)
+
+    @staticmethod
+    def _validate_esd_policy(listener_protocol, esd_key):
+        proto_map = constants.VALID_LISTENER_ESD_MAP
+        for valid_esd_key in proto_map.get(listener_protocol, []):
+            if esd_key == valid_esd_key:
+                return
+        detail = _("The extended policy '%(esd_key)s' is invalid while "
+                   "the listener protocol is '%(listener_protocol)s'.") % {
+                       "esd_key": esd_key,
+                       "listener_protocol": listener_protocol}
+        raise exceptions.ValidationException(detail=detail)
+
+    @staticmethod
+    def _validate_policy_action_for_esd(L7policy_action):
+        if L7policy_action == constants.L7POLICY_ACTION_REJECT:
+            return
+        detail = _("The extended policy can be added only with "
+                   "%(allowed_action)s l7 policy action.") % {
+                       "allowed_action": constants.L7POLICY_ACTION_REJECT}
+        raise exceptions.ValidationException(detail=detail)

--- a/octavia/api/v2/controllers/l7policy.py
+++ b/octavia/api/v2/controllers/l7policy.py
@@ -134,6 +134,11 @@ class L7PolicyController(base.BaseController):
                 context.session, l7policy.redirect_pool_id)
             self._validate_protocol(listener.protocol, db_pool.protocol)
 
+        # Check ESD policies if this listener supports only them
+        if listener.protocol in constants.ONLY_ESD_L7POLICY_PROTO:
+            self._validate_esd_policy(listener.protocol, l7policy.name)
+            self._validate_policy_action_for_esd(l7policy.action)
+
         # Load the driver early as it also provides validation
         driver = driver_factory.get_driver(provider)
 
@@ -225,6 +230,13 @@ class L7PolicyController(base.BaseController):
             db_pool = self._get_db_pool(
                 context.session, l7policy_dict['redirect_pool_id'])
             self._validate_protocol(listener.protocol, db_pool.protocol)
+
+        # Check ESD policies if this listener supports only them
+        if listener.protocol in constants.ONLY_ESD_L7POLICY_PROTO:
+            if l7policy_dict.get('name'):
+                self._validate_esd_policy(listener.protocol, l7policy.name)
+            if l7policy_dict.get('action'):
+                self._validate_policy_action_for_esd(l7policy.action)
 
         # Load the driver early as it also provides validation
         driver = driver_factory.get_driver(provider)

--- a/octavia/common/constants.py
+++ b/octavia/common/constants.py
@@ -213,6 +213,23 @@ VALID_LISTENER_POOL_PROTOCOL_MAP = {
     PROTOCOL_TERMINATED_HTTPS: [PROTOCOL_HTTP, PROTOCOL_PROXY],
     PROTOCOL_UDP: [PROTOCOL_UDP]}
 
+L4_ESD_POLICIES = ['proxy_protocol_2edF_v1_0', 'proxy_protocol_V2_e8f6_v1_0',
+                   'standard_tcp_a3de_v1_0']
+L7_ESD_POLICIES = ['x_forward_5b6e_v1_0', 'one_connect_dd5c_v1_0',
+                   'no_one_connect_3caB_v1_0', 'http_compression_e4a2_v1_0',
+                   'cookie_encryption_b82a_v1_0', 'sso_22b0_v1_0',
+                   'sso_required_f544_v1_0', 'http_redirect_a26c_v1_0',
+                   'hcm_rmk_restrict_internal']
+VALID_LISTENER_ESD_MAP = {
+    PROTOCOL_PROXY: L4_ESD_POLICIES,
+    PROTOCOL_TCP: L4_ESD_POLICIES,
+    PROTOCOL_HTTP: L4_ESD_POLICIES + L7_ESD_POLICIES,
+    PROTOCOL_HTTPS: L4_ESD_POLICIES,
+    PROTOCOL_TERMINATED_HTTPS: L4_ESD_POLICIES + L7_ESD_POLICIES,
+    PROTOCOL_UDP: [],
+}
+ONLY_ESD_L7POLICY_PROTO = [PROTOCOL_PROXY, PROTOCOL_TCP, PROTOCOL_HTTPS]
+
 # API Integer Ranges
 MIN_PORT_NUMBER = 1
 MAX_PORT_NUMBER = 65535

--- a/octavia/tests/functional/api/v2/test_l7policy.py
+++ b/octavia/tests/functional/api/v2/test_l7policy.py
@@ -1316,6 +1316,152 @@ class TestL7Policy(base.BaseAPITest):
                     l7policy_id=l7policy.get('id')),
                     status=404)
 
+    def test_invalid_listener_protocol_esd_l7policy_post(self):
+        l7policy = {
+            'action': constants.L7POLICY_ACTION_REJECT,
+            'name': 'some-random-name',
+        }
+        port = 1
+        for listener_proto in constants.ONLY_ESD_L7POLICY_PROTO:
+            port = port + 1
+            listener = self.create_listener(
+                listener_proto, port, self.lb_id).get('listener')
+            self.set_object_status(self.lb_repo, self.lb_id)
+            l7policy['listener_id'] = listener.get('id')
+            expect_error_msg = ("Validation failure: The extended policy "
+                                "'some-random-name' is invalid while the "
+                                "listener protocol is '%s'.") % listener_proto
+            res = self.post(self.L7POLICIES_PATH,
+                            self._build_body(l7policy), status=400)
+            self.assertEqual(expect_error_msg, res.json['faultstring'])
+            self.assert_correct_status(lb_id=self.lb_id)
+
+    def test_invalid_policy_action_esd_l7policy_post(self):
+        l7policy = {
+            'action': constants.L7POLICY_ACTION_REDIRECT_TO_URL,
+        }
+        port = 1
+        for listener_proto in constants.ONLY_ESD_L7POLICY_PROTO:
+            port = port + 1
+            listener = self.create_listener(
+                listener_proto, port, self.lb_id).get('listener')
+            self.set_object_status(self.lb_repo, self.lb_id)
+            l7policy['listener_id'] = listener.get('id')
+            for esd_name in constants.VALID_LISTENER_ESD_MAP[listener_proto]:
+                l7policy['name'] = esd_name
+                expect_error_msg = ("Validation failure: The extended policy"
+                                    " can be added only with REJECT l7"
+                                    " policy action.")
+                res = self.post(self.L7POLICIES_PATH,
+                                self._build_body(l7policy), status=400)
+                self.assertEqual(expect_error_msg, res.json['faultstring'])
+                self.assert_correct_status(lb_id=self.lb_id)
+
+    @mock.patch('octavia.common.tls_utils.cert_parser.load_certificates_data')
+    def test_listener_protocol_esd_l7policy_map_post(self, mock_cert_data):
+        cert = data_models.TLSContainer(certificate='cert')
+        mock_cert_data.return_value = {'sni_certs': [cert]}
+        l7policy = {
+            'action': constants.L7POLICY_ACTION_REJECT,
+        }
+        port = 1
+        for listener_proto in constants.VALID_LISTENER_POOL_PROTOCOL_MAP:
+            port = port + 1
+            opts = {}
+            if listener_proto == constants.PROTOCOL_TERMINATED_HTTPS:
+                opts['sni_container_refs'] = [uuidutils.generate_uuid()]
+            listener = self.create_listener(
+                listener_proto, port, self.lb_id, **opts).get('listener')
+            self.set_object_status(self.lb_repo, self.lb_id)
+            l7policy['listener_id'] = listener.get('id')
+            for esd_name in constants.VALID_LISTENER_ESD_MAP[listener_proto]:
+                l7policy['name'] = esd_name
+                self.post(self.L7POLICIES_PATH,
+                          self._build_body(l7policy), status=201)
+                self.set_object_status(self.lb_repo, self.lb_id)
+
+    def test_invalid_listener_protocol_esd_l7policy_put(self):
+        new_l7policy = {
+            'action': constants.L7POLICY_ACTION_REJECT,
+            'name': 'some-random-name',
+        }
+        port = 1
+        for listener_proto in constants.ONLY_ESD_L7POLICY_PROTO:
+            port = port + 1
+            listener = self.create_listener(
+                listener_proto, port, self.lb_id).get('listener')
+            self.set_object_status(self.lb_repo, self.lb_id)
+            l7policy = self.create_l7policy(
+                listener.get('id'),
+                constants.L7POLICY_ACTION_REJECT,
+                name=constants.VALID_LISTENER_ESD_MAP[listener_proto][0],
+            ).get(self.root_tag)
+            self.set_object_status(self.lb_repo, self.lb_id)
+            expect_error_msg = ("Validation failure: The extended policy "
+                                "'some-random-name' is invalid while the "
+                                "listener protocol is '%s'.") % listener_proto
+            res = self.put(self.L7POLICY_PATH.format(
+                l7policy_id=l7policy.get('id')),
+                self._build_body(new_l7policy), status=400)
+            self.assertEqual(expect_error_msg, res.json['faultstring'])
+            self.assert_correct_status(lb_id=self.lb_id)
+
+    def test_invalid_policy_action_esd_l7policy_put(self):
+        new_l7policy = {
+            'action': constants.L7POLICY_ACTION_REDIRECT_TO_URL,
+            'redirect_url': 'http://www.example.com',
+        }
+        port = 1
+        for listener_proto in constants.ONLY_ESD_L7POLICY_PROTO:
+            port = port + 1
+            listener = self.create_listener(
+                listener_proto, port, self.lb_id).get('listener')
+            self.set_object_status(self.lb_repo, self.lb_id)
+            for esd_name in constants.VALID_LISTENER_ESD_MAP[listener_proto]:
+                l7policy = self.create_l7policy(
+                    listener.get('id'),
+                    constants.L7POLICY_ACTION_REJECT,
+                    name=esd_name,
+                ).get(self.root_tag)
+                self.set_object_status(self.lb_repo, self.lb_id)
+                expect_error_msg = ("Validation failure: The extended policy"
+                                    " can be added only with REJECT l7"
+                                    " policy action.")
+                res = self.put(self.L7POLICY_PATH.format(
+                    l7policy_id=l7policy.get('id')),
+                    self._build_body(new_l7policy), status=400)
+                self.assertEqual(expect_error_msg, res.json['faultstring'])
+                self.assert_correct_status(lb_id=self.lb_id)
+
+    @mock.patch('octavia.common.tls_utils.cert_parser.load_certificates_data')
+    def test_listener_protocol_esd_l7policy_map_put(self, mock_cert_data):
+        cert = data_models.TLSContainer(certificate='cert')
+        mock_cert_data.return_value = {'sni_certs': [cert]}
+        new_l7policy = {
+            'action': constants.L7POLICY_ACTION_REJECT,
+        }
+        port = 1
+        for listener_proto in constants.VALID_LISTENER_POOL_PROTOCOL_MAP:
+            port = port + 1
+            opts = {}
+            if listener_proto == constants.PROTOCOL_TERMINATED_HTTPS:
+                opts['sni_container_refs'] = [uuidutils.generate_uuid()]
+            listener = self.create_listener(
+                listener_proto, port, self.lb_id, **opts).get('listener')
+            self.set_object_status(self.lb_repo, self.lb_id)
+            for esd_name in constants.VALID_LISTENER_ESD_MAP[listener_proto]:
+                l7policy = self.create_l7policy(
+                    listener.get('id'),
+                    constants.L7POLICY_ACTION_REJECT,
+                    name=esd_name,
+                ).get(self.root_tag)
+                self.set_object_status(self.lb_repo, self.lb_id)
+                new_l7policy['name'] = esd_name
+                self.put(
+                    self.L7POLICY_PATH.format(l7policy_id=l7policy.get('id')),
+                    self._build_body(new_l7policy), status=200)
+                self.set_object_status(self.lb_repo, self.lb_id)
+
     @mock.patch('octavia.common.tls_utils.cert_parser.load_certificates_data')
     def test_listener_pool_protocol_map_post(self, mock_cert_data):
         cert = data_models.TLSContainer(certificate='cert')
@@ -1324,6 +1470,11 @@ class TestL7Policy(base.BaseAPITest):
         port = 1
         l7policy = {'action': constants.L7POLICY_ACTION_REDIRECT_TO_POOL}
         for listener_proto in valid_map:
+            # We can ignore several protocols here, because they tested in
+            # test_listener.py and also these cases tested in previous tests
+            # for ESD policies.
+            if listener_proto in constants.ONLY_ESD_L7POLICY_PROTO:
+                continue
             for pool_proto in valid_map[listener_proto]:
                 port = port + 1
                 opts = {}
@@ -1335,7 +1486,6 @@ class TestL7Policy(base.BaseAPITest):
                 pool = self.create_pool(
                     self.lb_id, pool_proto,
                     constants.LB_ALGORITHM_ROUND_ROBIN).get('pool')
-
                 l7policy['listener_id'] = listener.get('id')
                 l7policy['redirect_pool_id'] = pool.get('id')
                 self.set_object_status(self.lb_repo, self.lb_id)
@@ -1378,6 +1528,11 @@ class TestL7Policy(base.BaseAPITest):
         port = 1
         new_l7policy = {'action': constants.L7POLICY_ACTION_REDIRECT_TO_POOL}
         for listener_proto in valid_map:
+            # We can ignore several protocols here, because they tested in
+            # test_listener.py and also these cases tested in previous tests
+            # for ESD policies.
+            if listener_proto in constants.ONLY_ESD_L7POLICY_PROTO:
+                continue
             for pool_proto in valid_map[listener_proto]:
                 port = port + 1
                 opts = {}
@@ -1404,6 +1559,11 @@ class TestL7Policy(base.BaseAPITest):
         invalid_map = c_const.INVALID_LISTENER_POOL_PROTOCOL_MAP
         port = 100
         for listener_proto in invalid_map:
+            # We can ignore several protocols here, because they tested in
+            # test_listener.py and also these cases tested in previous tests
+            # for ESD policies.
+            if listener_proto in constants.ONLY_ESD_L7POLICY_PROTO:
+                continue
             opts = {}
             if listener_proto == constants.PROTOCOL_TERMINATED_HTTPS:
                 opts['sni_container_refs'] = [uuidutils.generate_uuid()]


### PR DESCRIPTION
In our cloud user can set extended policy in two ways:
1. by setting [the special keys](https://documentation.global.cloud.sap/networking/lbaas-details#extended-policies-ccloud-specific) as `tags` for a listener;
2. by creating L7 policies and using [the special keys](https://documentation.global.cloud.sap/networking/lbaas-details#extended-policies-ccloud-specific) as a `name` for these policies and with REJECT policy action;

So we cannot totally disallow L7 policies for TCP, PROXY, and HTTPS (underhood TCP) listener protocols. We must support extended policies that have the special name and REJECT action. Of course, we can catch the error on octavia-f5-driver side and set ERROR provisioning_status for a listener with the wrong L7 policy, but I think it better to add new checks on Octavia API side. As a result, our users will get (and see) the understandable errors instead of listeners/loadbalancer with ERROR status. At least, it will improve customer experience.

This PR adds such checks to the API level. We will store the valid map `protocol -> esd policy name` in constants (maybe better store these constants in octavia-f5-driver and include them from it?) and validate all combinations. These checks allow to create L7 policies with special names and REJECT action for TCP, PROXY, HTTPS protocols.

I see only one problem: if we will update the list of extended policy keys really often we have to update the source code.

Closes: #11 
 