### PR TITLE
Add endpoints migrate and <id>/migrate to /v2/lbaas/loadbalancers

### DIFF
--- a/octavia/api/v2/controllers/load_balancer.py
+++ b/octavia/api/v2/controllers/load_balancer.py
@@ -666,10 +666,15 @@ class LoadBalancersController(base.BaseController):
         'statuses' is aliased here for backward compatibility with
         neutron-lbaas LBaaS v2 API.
         """
+
+        if id == 'migrate' and not remainder:
+            return MigrationController(), remainder
+
         is_children = (
             id and remainder and (
                 remainder[0] == 'status' or remainder[0] == 'statuses' or (
                     remainder[0] == 'stats' or remainder[0] == 'failover'
+                    or remainder[0] == 'migrate'
                 )
             )
         )
@@ -682,6 +687,8 @@ class LoadBalancersController(base.BaseController):
                 return StatisticsController(lb_id=id), remainder
             elif controller == 'failover':
                 return FailoverController(lb_id=id), remainder
+            elif controller == 'migrate':
+                return LoadBalancerMigrationController(lb_id=id), remainder
         return None
 
 
@@ -767,3 +774,50 @@ class FailoverController(LoadBalancersController):
                      "provider %s", self.lb_id, driver.name)
             driver_utils.call_provider(
                 driver.name, driver.loadbalancer_failover, self.lb_id)
+
+
+class MigrationController(LoadBalancersController):
+
+    def __init__(self):
+        super(MigrationController, self).__init__()
+
+    @wsme_pecan.wsexpose(None, wtypes.text, wtypes.text, status_code=202)
+    def put(self, source_host, target_host, **kwargs):
+        """Migrates all load balancers from source_host to target_host"""
+        context = pecan.request.context.get('octavia_context')
+
+        if not (context.to_policy_values().get('is_admin') or context.is_admin):
+            LOG.error("Load balancer migration request: No admin. Unauthorized.")
+            return
+
+        driver = driver_factory.get_driver('f5')
+        LOG.info("Sending migration request with source host %s and target host "
+                 "%s to the provider %s", source_host, target_host, driver.name)
+        driver_utils.call_provider(
+            driver.name, driver.loadbalancers_migrate, source_host, target_host)
+
+
+class LoadBalancerMigrationController(LoadBalancersController):
+
+    def __init__(self, lb_id):
+        super(LoadBalancerMigrationController, self).__init__()
+        self.lb_id = lb_id
+
+    @wsme_pecan.wsexpose(None, wtypes.text, wtypes.text, status_code=202)
+    def put(self, target_host, **kwargs):
+        """Migrates one load balancer to a target host"""
+        context = pecan.request.context.get('octavia_context')
+        db_lb = self._get_db_lb(context.session, self.lb_id,
+                                show_deleted=False)
+
+        if not (context.to_policy_values().get('is_admin') or context.is_admin):
+            LOG.error("Load balancer migration request: No admin. Unauthorized.")
+            return
+
+        # Load the driver early as it also provides validation
+        driver = driver_factory.get_driver(db_lb.provider)
+
+        LOG.info("Sending migration request with target host %s for load balancer "
+                 "%s to the provider %s", target_host, self.lb_id, driver.name)
+        driver_utils.call_provider(
+            driver.name, driver.loadbalancer_migrate, self.lb_id, target_host)

--- a/octavia/controller/queue/endpoint.py
+++ b/octavia/controller/queue/endpoint.py
@@ -59,6 +59,16 @@ class Endpoint(object):
                  load_balancer_id)
         self.worker.failover_loadbalancer(load_balancer_id)
 
+    def migrate_load_balancer(self, context, load_balancer_id, target_host):
+        LOG.info('Migrating load balancer %s to host \'%s\'...',
+                 load_balancer_id, target_host)
+        self.worker.migrate_loadbalancer(load_balancer_id, target_host)
+
+    def migrate_load_balancers(self, context, source_host, target_host):
+        LOG.info('Migrating load balancers from host \'%s\' to host \'%s\'...',
+                 source_host, target_host)
+        self.worker.migrate_loadbalancers(source_host, target_host)
+
     def failover_amphora(self, context, amphora_id):
         LOG.info('Failing over amphora \'%s\'...',
                  amphora_id)


### PR DESCRIPTION
`/v2/lbaas/loadbalancers/migrate` is for migrating all load balancers from one host to another. Arguments in the body are source_host and target_host.

`/v2/lbaas/loadbalancers/<id>/migrate` is for migrating one load balancer from its host to another. The only argument in the body is target_host.

The endpoints use static authentication for now (only admin is allowed to use them). This is also done because we can't provide e. g. a project to Octavias authentication mechanism, because there might be several projects on the host from which is migrated.