### PR TITLE
Quota PUT endpoint: Add l7policy parameter

### DIFF
--- a/octavia/api/v2/types/quotas.py
+++ b/octavia/api/v2/types/quotas.py
@@ -33,6 +33,9 @@ class QuotaBase(base.BaseType):
         minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
     healthmonitor = wtypes.wsattr(wtypes.IntegerType(
         minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
+    l7policy = wtypes.wsattr(wtypes.IntegerType(
+        minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
+
     # Misspelled version, deprecated in Rocky
     health_monitor = wtypes.wsattr(wtypes.IntegerType(
         minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))


### PR DESCRIPTION
Since Limes is now talking directly to Octavia, it is (always has
been) trying to set quotas for l7policies, among others.
Octavia stein does not allow this field though, so it errors out.

We don't want to add an exception to Limes, that would be removed
again anyway as soon as Octavia is updated (to a version supporting
l7policy quotas), so instead we just allow the l7policy field, but
ignore it.