### PR TITLE
Add quota_usage endpoint for v2 API.

### DIFF
--- a/octavia/api/v2/controllers/__init__.py
+++ b/octavia/api/v2/controllers/__init__.py
@@ -26,6 +26,7 @@ from octavia.api.v2.controllers import load_balancer
 from octavia.api.v2.controllers import pool
 from octavia.api.v2.controllers import provider
 from octavia.api.v2.controllers import quotas
+from octavia.api.v2.controllers import quota_usage
 
 
 class BaseV2Controller(base.BaseController):
@@ -35,6 +36,7 @@ class BaseV2Controller(base.BaseController):
     l7policies = None
     healthmonitors = None
     quotas = None
+    quota_usage = None
 
     def __init__(self):
         super(BaseV2Controller, self).__init__()
@@ -44,6 +46,7 @@ class BaseV2Controller(base.BaseController):
         self.l7policies = l7policy.L7PolicyController()
         self.healthmonitors = health_monitor.HealthMonitorController()
         self.quotas = quotas.QuotasController()
+        self.quota_usage = quota_usage.QuotaUsageController()
         self.providers = provider.ProviderController()
         self.flavors = flavors.FlavorsController()
         self.flavorprofiles = flavor_profiles.FlavorProfileController()

--- a/octavia/api/v2/controllers/base.py
+++ b/octavia/api/v2/controllers/base.py
@@ -197,6 +197,34 @@ class BaseController(pecan.rest.RestController):
                 db_quotas.member = CONF.quotas.default_member_quota
         return db_quotas
 
+    def _get_db_quota_usage(self, session, project_id):
+        """Gets the project's quota usage from the database."""
+        # TODO(Vadim Ponomarev): use stored quota usage in database instead
+        # counting when we will fix quota counting inside f5 amphora driver.
+        loadbalancers = self.repositories.load_balancer.count(
+            session, project_id=project_id)
+        listeners = self.repositories.listener.count(
+            session, project_id=project_id)
+        pools = self.repositories.pool.count(
+            session, project_id=project_id)
+        members = self.repositories.member.count(
+            session, project_id=project_id)
+        l7policies = self.repositories.l7policy.count(
+            session, project_id=project_id)
+        l7rules = self.repositories.l7rule.count(
+            session, project_id=project_id)
+        health_monitors = self.repositories.health_monitor.count(
+            session, project_id=project_id)
+        return data_models.QuotaUsage(
+            load_balancers=loadbalancers,
+            listeners=listeners,
+            pools=pools,
+            members=members,
+            l7policies=l7policies,
+            l7rules=l7rules,
+            health_monitors=health_monitors,
+        )
+
     def _auth_get_all(self, context, project_id):
         # Check authorization to list objects under all projects
         action = '{rbac_obj}{action}'.format(

--- a/octavia/api/v2/controllers/base.py
+++ b/octavia/api/v2/controllers/base.py
@@ -201,28 +201,28 @@ class BaseController(pecan.rest.RestController):
         """Gets the project's quota usage from the database."""
         # TODO(Vadim Ponomarev): use stored quota usage in database instead
         # counting when we will fix quota counting inside f5 amphora driver.
-        loadbalancers = self.repositories.load_balancer.count(
+        loadbalancer = self.repositories.load_balancer.count(
             session, project_id=project_id)
-        listeners = self.repositories.listener.count(
+        listener = self.repositories.listener.count(
             session, project_id=project_id)
-        pools = self.repositories.pool.count(
+        pool = self.repositories.pool.count(
             session, project_id=project_id)
-        members = self.repositories.member.count(
+        member = self.repositories.member.count(
             session, project_id=project_id)
-        l7policies = self.repositories.l7policy.count(
+        l7policy = self.repositories.l7policy.count(
             session, project_id=project_id)
-        l7rules = self.repositories.l7rule.count(
+        l7rule = self.repositories.l7rule.count(
             session, project_id=project_id)
-        health_monitors = self.repositories.health_monitor.count(
+        healthmonitor = self.repositories.health_monitor.count(
             session, project_id=project_id)
         return data_models.QuotaUsage(
-            load_balancers=loadbalancers,
-            listeners=listeners,
-            pools=pools,
-            members=members,
-            l7policies=l7policies,
-            l7rules=l7rules,
-            health_monitors=health_monitors,
+            loadbalancer=loadbalancer,
+            listener=listener,
+            pool=pool,
+            member=member,
+            l7policy=l7policy,
+            l7rule=l7rule,
+            healthmonitor=healthmonitor,
         )
 
     def _auth_get_all(self, context, project_id):

--- a/octavia/api/v2/controllers/quota_usage.py
+++ b/octavia/api/v2/controllers/quota_usage.py
@@ -1,0 +1,39 @@
+#    Copyright 2016 Rackspace
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import pecan
+from wsme import types as wtypes
+from wsmeext import pecan as wsme_pecan
+
+from octavia.api.v2.controllers import base
+from octavia.api.v2.types import quotas as quota_types
+from octavia.common import constants
+
+
+class QuotaUsageController(base.BaseController):
+    RBAC_TYPE = constants.RBAC_QUOTA
+
+    def __init__(self):
+        super(QuotaUsageController, self).__init__()
+
+    @wsme_pecan.wsexpose(quota_types.QuotaUsageResponse, wtypes.text)
+    def get(self, project_id):
+        """Get a single project's quota usage."""
+        context = pecan.request.context.get('octavia_context')
+
+        self._auth_validate_action(context, project_id, constants.RBAC_GET_ONE)
+
+        db_quota_usage = self._get_db_quota_usage(context.session, project_id)
+        return self._convert_db_to_type(
+            db_quota_usage, quota_types.QuotaUsageResponse)

--- a/octavia/api/v2/types/quotas.py
+++ b/octavia/api/v2/types/quotas.py
@@ -63,19 +63,19 @@ class QuotaResponse(base.BaseType):
 
 class QuotaUsageBase(base.BaseType):
     """Individual quota definitions."""
-    load_balancers = wtypes.wsattr(wtypes.IntegerType(
+    loadbalancer = wtypes.wsattr(wtypes.IntegerType(
         minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
-    listeners = wtypes.wsattr(wtypes.IntegerType(
+    listener = wtypes.wsattr(wtypes.IntegerType(
         minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
-    members = wtypes.wsattr(wtypes.IntegerType(
+    member = wtypes.wsattr(wtypes.IntegerType(
         minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
-    pools = wtypes.wsattr(wtypes.IntegerType(
+    pool = wtypes.wsattr(wtypes.IntegerType(
         minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
-    l7policies = wtypes.wsattr(wtypes.IntegerType(
+    l7policy = wtypes.wsattr(wtypes.IntegerType(
         minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
-    l7rules = wtypes.wsattr(wtypes.IntegerType(
+    l7rule = wtypes.wsattr(wtypes.IntegerType(
         minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
-    health_monitors = wtypes.wsattr(wtypes.IntegerType(
+    healthmonitor = wtypes.wsattr(wtypes.IntegerType(
         minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
 
 

--- a/octavia/api/v2/types/quotas.py
+++ b/octavia/api/v2/types/quotas.py
@@ -61,6 +61,36 @@ class QuotaResponse(base.BaseType):
         return quotas
 
 
+class QuotaUsageBase(base.BaseType):
+    """Individual quota definitions."""
+    load_balancers = wtypes.wsattr(wtypes.IntegerType(
+        minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
+    listeners = wtypes.wsattr(wtypes.IntegerType(
+        minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
+    members = wtypes.wsattr(wtypes.IntegerType(
+        minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
+    pools = wtypes.wsattr(wtypes.IntegerType(
+        minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
+    l7policies = wtypes.wsattr(wtypes.IntegerType(
+        minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
+    l7rules = wtypes.wsattr(wtypes.IntegerType(
+        minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
+    health_monitors = wtypes.wsattr(wtypes.IntegerType(
+        minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
+
+
+class QuotaUsageResponse(base.BaseType):
+    """Wrapper object for quotas responses."""
+    quota_usage = wtypes.wsattr(QuotaUsageBase)
+
+    @classmethod
+    def from_data_model(cls, data_model, children=False):
+        response = super(QuotaUsageResponse, cls).from_data_model(
+            data_model, children=children)
+        response.quota_usage = QuotaUsageBase.from_data_model(data_model)
+        return response
+
+
 class QuotaAllBase(base.BaseType):
     """Wrapper object for get all quotas responses."""
     project_id = wtypes.wsattr(wtypes.StringType())

--- a/octavia/common/data_models.py
+++ b/octavia/common/data_models.py
@@ -760,20 +760,20 @@ class Quotas(BaseDataModel):
 class QuotaUsage(BaseDataModel):
 
     def __init__(self,
-                 load_balancers=None,
-                 listeners=None,
-                 pools=None,
-                 health_monitors=None,
-                 members=None,
-                 l7policies=None,
-                 l7rules=None):
-        self.health_monitors = health_monitors
-        self.listeners = listeners
-        self.load_balancers = load_balancers
-        self.pools = pools
-        self.members = members
-        self.l7policies = l7policies
-        self.l7rules = l7rules
+                 loadbalancer=None,
+                 listener=None,
+                 pool=None,
+                 healthmonitor=None,
+                 member=None,
+                 l7policy=None,
+                 l7rule=None):
+        self.healthmonitor = healthmonitor
+        self.listener = listener
+        self.loadbalancer = loadbalancer
+        self.pool = pool
+        self.member = member
+        self.l7policy = l7policy
+        self.l7rule = l7rule
 
 
 class Flavor(BaseDataModel):

--- a/octavia/common/data_models.py
+++ b/octavia/common/data_models.py
@@ -757,6 +757,25 @@ class Quotas(BaseDataModel):
         self.in_use_pool = in_use_pool
 
 
+class QuotaUsage(BaseDataModel):
+
+    def __init__(self,
+                 load_balancers=None,
+                 listeners=None,
+                 pools=None,
+                 health_monitors=None,
+                 members=None,
+                 l7policies=None,
+                 l7rules=None):
+        self.health_monitors = health_monitors
+        self.listeners = listeners
+        self.load_balancers = load_balancers
+        self.pools = pools
+        self.members = members
+        self.l7policies = l7policies
+        self.l7rules = l7rules
+
+
 class Flavor(BaseDataModel):
 
     def __init__(self, id=None, name=None,

--- a/octavia/tests/functional/api/v2/base.py
+++ b/octavia/tests/functional/api/v2/base.py
@@ -73,6 +73,8 @@ class BaseAPITest(base_db_test.OctaviaDBTestBase):
     QUOTA_PATH = QUOTAS_PATH + '/{project_id}'
     QUOTA_DEFAULT_PATH = QUOTAS_PATH + '/{project_id}/default'
 
+    QUOTA_USAGE_PATH = '/lbaas/quota_usage/{project_id}'
+
     AMPHORAE_PATH = '/octavia/amphorae'
     AMPHORA_PATH = AMPHORAE_PATH + '/{amphora_id}'
     AMPHORA_FAILOVER_PATH = AMPHORA_PATH + '/failover'

--- a/octavia/tests/functional/api/v2/test_quota_usage.py
+++ b/octavia/tests/functional/api/v2/test_quota_usage.py
@@ -82,22 +82,22 @@ class TestQuotaUsage(base.BaseAPITest):
                                   name='lb2', project_id=project2_id,
                                   tags=['test_tag2'])
         usage1 = {
-            'health_monitors': 1,
-            'listeners': 1,
-            'load_balancers': 1,
-            'pools': 1,
-            'members': 2,
-            'l7policies': 1,
-            'l7rules': 1,
+            'healthmonitor': 1,
+            'listener': 1,
+            'loadbalancer': 1,
+            'pool': 1,
+            'member': 2,
+            'l7policy': 1,
+            'l7rule': 1,
         }
         usage2 = {
-            'health_monitors': 0,
-            'listeners': 0,
-            'load_balancers': 1,
-            'pools': 0,
-            'members': 0,
-            'l7policies': 0,
-            'l7rules': 0,
+            'healthmonitor': 0,
+            'listener': 0,
+            'loadbalancer': 1,
+            'pool': 0,
+            'member': 0,
+            'l7policy': 0,
+            'l7rule': 0,
         }
 
         quota_usage = self.get(
@@ -153,13 +153,13 @@ class TestQuotaUsage(base.BaseAPITest):
                 ).json.get(self.root_tag)
         self.conf.config(group='api_settings', auth_strategy=auth_strategy)
         usage = {
-            'health_monitors': 0,
-            'listeners': 0,
-            'load_balancers': 1,
-            'pools': 0,
-            'members': 0,
-            'l7policies': 0,
-            'l7rules': 0,
+            'healthmonitor': 0,
+            'listener': 0,
+            'loadbalancer': 1,
+            'pool': 0,
+            'member': 0,
+            'l7policy': 0,
+            'l7rule': 0,
         }
         self.assertEqual(usage, result)
 

--- a/octavia/tests/functional/api/v2/test_quota_usage.py
+++ b/octavia/tests/functional/api/v2/test_quota_usage.py
@@ -1,0 +1,237 @@
+# Copyright 2016 Rackspace
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import random
+
+import mock
+from oslo_config import cfg
+from oslo_config import fixture as oslo_fixture
+from oslo_utils import uuidutils
+
+from octavia.common import constants
+import octavia.common.context
+from octavia.tests.functional.api.v2 import base
+
+CONF = cfg.CONF
+
+
+class TestQuotaUsage(base.BaseAPITest):
+
+    root_tag = 'quota_usage'
+
+    def setUp(self):
+        super(TestQuotaUsage, self).setUp()
+        self.project_id = uuidutils.generate_uuid()
+
+    def test_get_by_project_id(self):
+        project1_id = uuidutils.generate_uuid()
+        project2_id = uuidutils.generate_uuid()
+        # Create first load balancer with sub-resources
+        lb1 = self.create_load_balancer(uuidutils.generate_uuid(),
+                                        name='lb1', project_id=project1_id,
+                                        tags=['test_tag1'])
+        lb1_id = lb1.get('loadbalancer').get('id')
+        self.set_lb_status(lb1_id)
+        listener1 = self.create_listener(
+            constants.PROTOCOL_HTTP, 80, lb1_id,
+            tags=['test_tag1'])
+        listener1_id = listener1.get('listener').get('id')
+        self.set_lb_status(lb1_id)
+        pool1 = self.create_pool(
+            lb1_id,
+            constants.PROTOCOL_HTTP,
+            constants.LB_ALGORITHM_ROUND_ROBIN,
+            listener_id=listener1_id)
+        pool1_id = pool1.get('pool').get('id')
+        self.set_lb_status(lb1_id)
+        self.set_object_status(self.pool_repo, pool1_id)
+        self.create_member(
+            pool1_id, '192.0.2.1', 80)
+        self.set_lb_status(lb1_id)
+        self.set_object_status(self.pool_repo, pool1_id)
+        self.create_member(
+            pool1_id, '192.0.2.2', 80)
+        self.set_lb_status(lb1_id)
+        self.create_health_monitor(
+            pool1_id, constants.HEALTH_MONITOR_HTTP,
+            1, 1, 1, 1)
+        self.set_lb_status(lb1_id)
+        l7policy1 = self.create_l7policy(
+            listener1_id,
+            constants.L7POLICY_ACTION_REJECT,
+            tags=['test_tag'])
+        l7policy1_id = l7policy1.get('l7policy').get('id')
+        self.set_lb_status(lb1_id)
+        self.create_l7rule(
+            l7policy1_id, constants.L7RULE_TYPE_PATH,
+            constants.L7RULE_COMPARE_TYPE_STARTS_WITH,
+            '/api', tags=['test_tag'])
+        # Create second load balancer without any sub-resources
+        self.create_load_balancer(uuidutils.generate_uuid(),
+                                  name='lb2', project_id=project2_id,
+                                  tags=['test_tag2'])
+        usage1 = {
+            'health_monitors': 1,
+            'listeners': 1,
+            'load_balancers': 1,
+            'pools': 1,
+            'members': 2,
+            'l7policies': 1,
+            'l7rules': 1,
+        }
+        usage2 = {
+            'health_monitors': 0,
+            'listeners': 0,
+            'load_balancers': 1,
+            'pools': 0,
+            'members': 0,
+            'l7policies': 0,
+            'l7rules': 0,
+        }
+
+        quota_usage = self.get(
+            self.QUOTA_USAGE_PATH.format(project_id=project1_id)
+        ).json.get(self.root_tag)
+        self.assertEqual(usage1, quota_usage)
+        quota_usage = self.get(
+            self.QUOTA_USAGE_PATH.format(project_id=project2_id)
+        ).json.get(self.root_tag)
+        self.assertEqual(usage2, quota_usage)
+
+    def test_get_Authorized_member(self):
+        self._test_get_Authorized('load-balancer_member')
+
+    def test_get_Authorized_observer(self):
+        self._test_get_Authorized('load-balancer_observer')
+
+    def test_get_Authorized_global_observer(self):
+        self._test_get_Authorized('load-balancer_global_observer')
+
+    def test_get_Authorized_quota_admin(self):
+        self._test_get_Authorized('load-balancer_quota_admin')
+
+    def _test_get_Authorized(self, role):
+        project1_id = uuidutils.generate_uuid()
+        self.create_load_balancer(uuidutils.generate_uuid(),
+                                  name='lb2', project_id=project1_id,
+                                  tags=['test_tag2'])
+        self.conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
+
+        auth_strategy = self.conf.conf.api_settings.get('auth_strategy')
+        self.conf.config(group='api_settings', auth_strategy=constants.TESTING)
+        with mock.patch.object(octavia.common.context.Context, 'project_id',
+                               project1_id):
+            override_credentials = {
+                'service_user_id': None,
+                'user_domain_id': None,
+                'is_admin_project': True,
+                'service_project_domain_id': None,
+                'service_project_id': None,
+                'roles': [role],
+                'user_id': None,
+                'is_admin': False,
+                'service_user_domain_id': None,
+                'project_domain_id': None,
+                'service_roles': [],
+                'project_id': project1_id}
+            with mock.patch(
+                    "oslo_context.context.RequestContext.to_policy_values",
+                    return_value=override_credentials):
+                result = self.get(
+                    self.QUOTA_USAGE_PATH.format(project_id=project1_id)
+                ).json.get(self.root_tag)
+        self.conf.config(group='api_settings', auth_strategy=auth_strategy)
+        usage = {
+            'health_monitors': 0,
+            'listeners': 0,
+            'load_balancers': 1,
+            'pools': 0,
+            'members': 0,
+            'l7policies': 0,
+            'l7rules': 0,
+        }
+        self.assertEqual(usage, result)
+
+    def test_get_not_Authorized(self):
+        project1_id = uuidutils.generate_uuid()
+        self.conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
+
+        auth_strategy = self.conf.conf.api_settings.get('auth_strategy')
+        self.conf.config(group='api_settings', auth_strategy=constants.TESTING)
+        with mock.patch.object(octavia.common.context.Context, 'project_id',
+                               uuidutils.generate_uuid()):
+            result = self.get(self.QUOTA_USAGE_PATH.format(project_id=project1_id),
+                              status=403)
+        self.conf.config(group='api_settings', auth_strategy=auth_strategy)
+        self.assertEqual(self.NOT_AUTHORIZED_BODY, result.json)
+
+    def test_get_not_Authorized_bogus_role(self):
+        project1_id = uuidutils.generate_uuid()
+        self.conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
+
+        auth_strategy = self.conf.conf.api_settings.get('auth_strategy')
+        self.conf.config(group='api_settings', auth_strategy=constants.TESTING)
+        with mock.patch.object(octavia.common.context.Context, 'project_id',
+                               project1_id):
+            override_credentials = {
+                'service_user_id': None,
+                'user_domain_id': None,
+                'is_admin_project': True,
+                'service_project_domain_id': None,
+                'service_project_id': None,
+                'roles': ['load-balancer:bogus'],
+                'user_id': None,
+                'is_admin': False,
+                'service_user_domain_id': None,
+                'project_domain_id': None,
+                'service_roles': [],
+                'project_id': project1_id}
+            with mock.patch(
+                    "oslo_context.context.RequestContext.to_policy_values",
+                    return_value=override_credentials):
+                result = self.get(
+                    self.QUOTA_USAGE_PATH.format(project_id=project1_id),
+                    status=403)
+        self.conf.config(group='api_settings', auth_strategy=auth_strategy)
+        self.assertEqual(self.NOT_AUTHORIZED_BODY, result.json)
+
+    def test_get_not_Authorized_no_role(self):
+        project1_id = uuidutils.generate_uuid()
+        self.conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
+
+        auth_strategy = self.conf.conf.api_settings.get('auth_strategy')
+        self.conf.config(group='api_settings', auth_strategy=constants.TESTING)
+        with mock.patch.object(octavia.common.context.Context, 'project_id',
+                               project1_id):
+            override_credentials = {
+                'service_user_id': None,
+                'user_domain_id': None,
+                'is_admin_project': True,
+                'service_project_domain_id': None,
+                'service_project_id': None,
+                'roles': [],
+                'user_id': None,
+                'is_admin': False,
+                'service_user_domain_id': None,
+                'project_domain_id': None,
+                'service_roles': [],
+                'project_id': project1_id}
+            with mock.patch(
+                    "oslo_context.context.RequestContext.to_policy_values",
+                    return_value=override_credentials):
+                result = self.get(
+                    self.QUOTA_USAGE_PATH.format(project_id=project1_id),
+                    status=403)
+        self.conf.config(group='api_settings', auth_strategy=auth_strategy)
+        self.assertEqual(self.NOT_AUTHORIZED_BODY, result.json)


### PR DESCRIPTION
This PR adds a new endpoint `quota_usage` to get all quota usage counters in one API request by `project_id`. Endpoint URL: `/v2/lbaas/quota_usage/{project_id}` accept `GET` request and returns something like:

```
"quota_usage": {
    "healthmonitor": 1,
    "listener": 1,
    "loadbalancer": 1,
    "pool": 1,
    "member": 2,
    "l7policy": 1,
    "l7rule": 1,
}
```

For now, this endpoint does several requests to the database to count number of resources, but in the future, we have to use data stored in `quota` table. 