### PR TITLE
Add check for ESD policies passed in tags of listener

### DIFF
--- a/octavia/api/v2/controllers/listener.py
+++ b/octavia/api/v2/controllers/listener.py
@@ -119,6 +119,12 @@ class ListenersController(base.BaseController):
         self._validate_tls_option_proto(listener_protocol, db_pool.protocol,
                                         db_pool.tls_enabled)
 
+    def _validate_listener_tags(self, listener_protocol, listener_tags):
+        for tag in listener_tags:
+            if tag in constants.L4_ESD_POLICIES or \
+                    tag in constants.L7_ESD_POLICIES:
+                self._validate_esd_policy(listener_protocol, tag)
+
     def _has_tls_container_refs(self, listener_dict):
         return (listener_dict.get('tls_certificate_id') or
                 listener_dict.get('client_ca_tls_container_id') or
@@ -291,6 +297,10 @@ class ListenersController(base.BaseController):
                 self._validate_pool(context.session, load_balancer_id,
                                     listener_dict['default_pool_id'],
                                     listener.protocol)
+
+            if listener_dict.get('tags'):
+                self._validate_listener_tags(
+                    listener.protocol, listener_dict['tags'])
 
             self._test_lb_and_listener_statuses(
                 lock_session, lb_id=load_balancer_id)
@@ -468,6 +478,10 @@ class ListenersController(base.BaseController):
         if listener.default_pool_id:
             self._validate_pool(context.session, load_balancer_id,
                                 listener.default_pool_id, db_listener.protocol)
+
+        if listener.tags:
+            self._validate_listener_tags(
+                db_listener.protocol, listener.tags)
 
         # Load the driver early as it also provides validation
         driver = driver_factory.get_driver(provider)

--- a/octavia/tests/functional/api/v2/test_listener.py
+++ b/octavia/tests/functional/api/v2/test_listener.py
@@ -2288,6 +2288,108 @@ class TestListener(base.BaseAPITest):
                 listener.get('faultstring'))
 
     @mock.patch('octavia.common.tls_utils.cert_parser.load_certificates_data')
+    def test_create_with_valid_esd_tags_mapping(self, mock_cert_data):
+        cert = data_models.TLSContainer(certificate='cert')
+        mock_cert_data.return_value = {'tls_cert': cert}
+        port = 1
+        for listener_proto, esds in constants.VALID_LISTENER_ESD_MAP.items():
+            port = port + 1
+            lb_listener = {
+                'loadbalancer_id': self.lb_id,
+                'protocol': listener_proto,
+                'protocol_port': port,
+                'tags': ['some-other-tag'] + esds,
+            }
+            if listener_proto == constants.PROTOCOL_TERMINATED_HTTPS:
+                lb_listener['sni_container_refs'] = [uuidutils.generate_uuid()]
+            body = self._build_body(lb_listener)
+            self.set_lb_status(self.lb_id)
+            self.post(self.LISTENERS_PATH, body, status=201)
+
+    @mock.patch('octavia.common.tls_utils.cert_parser.load_certificates_data')
+    def test_create_with_invalid_esd_tags_mapping(self, mock_cert_data):
+        cert = data_models.TLSContainer(certificate='cert')
+        mock_cert_data.return_value = {'tls_cert': cert}
+        port = 1
+        all_esds = constants.L4_ESD_POLICIES + constants.L7_ESD_POLICIES
+        for listener_proto, esds in constants.VALID_LISTENER_ESD_MAP.items():
+            invalid_esds = set(all_esds) - set(esds)
+            if not invalid_esds:
+                continue
+            port = port + 1
+            lb_listener = {
+                'loadbalancer_id': self.lb_id,
+                'protocol': listener_proto,
+                'protocol_port': port,
+                'tags': ['some-other-tag'] + list(invalid_esds),
+            }
+            if listener_proto == constants.PROTOCOL_TERMINATED_HTTPS:
+                lb_listener['sni_container_refs'] = [uuidutils.generate_uuid()]
+            body = self._build_body(lb_listener)
+            self.set_lb_status(self.lb_id)
+            listener = self.post(self.LISTENERS_PATH, body, status=400).json
+            self.assertIn('The extended policy',
+                          listener.get('faultstring'))
+            self.assertIn('is invalid while the listener protocol is',
+                          listener.get('faultstring'))
+
+    @mock.patch('octavia.common.tls_utils.cert_parser.load_certificates_data')
+    def test_update_with_valid_esd_tags_mapping(self, mock_cert_data):
+        cert = data_models.TLSContainer(certificate='cert')
+        mock_cert_data.return_value = {'tls_cert': cert}
+        port = 1
+        for listener_proto, esds in constants.VALID_LISTENER_ESD_MAP.items():
+            port = port + 1
+            lb_listener = {
+                'loadbalancer_id': self.lb_id,
+                'protocol': listener_proto,
+                'protocol_port': port,
+            }
+            if listener_proto == constants.PROTOCOL_TERMINATED_HTTPS:
+                lb_listener['sni_container_refs'] = [uuidutils.generate_uuid()]
+            body = self._build_body(lb_listener)
+            self.set_lb_status(self.lb_id)
+            listener = self.post(self.LISTENERS_PATH, body, status=201).json
+            self.set_lb_status(self.lb_id)
+            new_listener = {'tags': ['some-other-tag'] + esds}
+            self.put(
+                self.LISTENER_PATH.format(
+                    listener_id=listener[self.root_tag].get('id')),
+                self._build_body(new_listener), status=200)
+
+    @mock.patch('octavia.common.tls_utils.cert_parser.load_certificates_data')
+    def test_update_with_invalid_esd_tags_mapping(self, mock_cert_data):
+        cert = data_models.TLSContainer(certificate='cert')
+        mock_cert_data.return_value = {'tls_cert': cert}
+        port = 1
+        all_esds = constants.L4_ESD_POLICIES + constants.L7_ESD_POLICIES
+        for listener_proto, esds in constants.VALID_LISTENER_ESD_MAP.items():
+            invalid_esds = set(all_esds) - set(esds)
+            if not invalid_esds:
+                continue
+            port = port + 1
+            lb_listener = {
+                'loadbalancer_id': self.lb_id,
+                'protocol': listener_proto,
+                'protocol_port': port,
+            }
+            if listener_proto == constants.PROTOCOL_TERMINATED_HTTPS:
+                lb_listener['sni_container_refs'] = [uuidutils.generate_uuid()]
+            body = self._build_body(lb_listener)
+            self.set_lb_status(self.lb_id)
+            listener = self.post(self.LISTENERS_PATH, body, status=201).json
+            self.set_lb_status(self.lb_id)
+            new_listener = {'tags': ['some-other-tag'] + list(invalid_esds)}
+            res = self.put(
+                self.LISTENER_PATH.format(
+                    listener_id=listener[self.root_tag].get('id')),
+                self._build_body(new_listener), status=400).json
+            self.assertIn('The extended policy',
+                          res.get('faultstring'))
+            self.assertIn('is invalid while the listener protocol is',
+                          res.get('faultstring'))
+
+    @mock.patch('octavia.common.tls_utils.cert_parser.load_certificates_data')
     def test_update_with_valid_insert_headers(self, mock_cert_data):
         cert1 = data_models.TLSContainer(certificate='cert 1')
         mock_cert_data.return_value = {'tls_cert': cert1}


### PR DESCRIPTION
This PR adds new checks for listener's POST/PUT endpoints to validate ESD policies in `tags` field. 