### PR TITLE
Allow all-ports listener (port 0), but only one per LB

### DIFF
--- a/octavia/api/v2/controllers/listener.py
+++ b/octavia/api/v2/controllers/listener.py
@@ -112,6 +112,26 @@ class ListenersController(base.BaseController):
                 raise exceptions.ImmutableObject(resource=db_lb._name(),
                                                  id=lb_id)
 
+    def _validate_allports_listeners(self, db_listener):
+        """If the listener listens on all ports (that is, it's port is set to 0), check that there is not already
+        another listener defined on the load balancer. Else, check that no other listener has it's port set to 0. """
+
+        # If listener creation happened to be fast enough before this method was called, the listener we're checking
+        # right now might end up already existing in the argument. Therefore we need to filter it out,
+        # else the validation fails if this listener is all-ports.
+        existing_listeners = [li for li in db_listener.load_balancer.listeners if li.id != db_listener.id]
+
+        # if there are no listeners yet we don't have a problem
+        if len(existing_listeners) == 0:
+            return
+
+        if db_listener.protocol_port == 0:
+            raise exceptions.ValidationException(
+                detail=_("Cannot create listener for all ports: Other listeners exist"))
+        if any(listener.protocol_port == 0 for listener in existing_listeners):
+            raise exceptions.ValidationException(
+                detail=_("Cannot create listener: A listener for all ports exists"))
+
     def _validate_pool(self, session, lb_id, pool_id, listener_protocol):
         """Validate pool given exists on same load balancer as listener."""
         db_pool = self.repositories.pool.get(
@@ -336,6 +356,7 @@ class ListenersController(base.BaseController):
         try:
             db_listener = self.repositories.listener.create(
                 lock_session, **listener_dict)
+            self._validate_allports_listeners(db_listener)
             if sni_containers:
                 for container in sni_containers:
                     sni_dict = {'listener_id': db_listener.id,

--- a/octavia/api/v2/controllers/load_balancer.py
+++ b/octavia/api/v2/controllers/load_balancer.py
@@ -630,6 +630,9 @@ class LoadBalancersController(base.BaseController):
             raise exceptions.QuotaException(
                 resource=data_models.Listener._name())
 
+        # Check that listeners don't conflict with each other
+        self._validate_internal_listener_conflicts(listeners)
+
         # Now create all of the listeners
         new_lists = []
         for li in listeners:
@@ -774,6 +777,13 @@ class LoadBalancersController(base.BaseController):
             elif controller == 'migrate':
                 return LoadBalancerMigrationController(lb_id=id), remainder
         return None
+
+    def _validate_internal_listener_conflicts(self, listeners):
+        """A load balancer must not have more than one all-ports listeners. If there are two or more listeners and
+        one of them is an all-ports listener, throw an error. """
+        if len(listeners) >= 2 and any(li['protocol_port'] == 0 for li in listeners):
+            raise exceptions.ValidationException(detail=_("Cannot create more than one listener: At least one "
+                                                          "all-ports listener was specified"))
 
 
 class StatusController(base.BaseController):

--- a/octavia/api/v2/types/listener.py
+++ b/octavia/api/v2/types/listener.py
@@ -114,7 +114,7 @@ class ListenerPOST(BaseListenerType):
     protocol = wtypes.wsattr(wtypes.Enum(str, *constants.SUPPORTED_PROTOCOLS),
                              mandatory=True)
     protocol_port = wtypes.wsattr(
-        wtypes.IntegerType(minimum=constants.MIN_PORT_NUMBER,
+        wtypes.IntegerType(minimum=constants.MIN_PORT_NUMBER_LISTENER,
                            maximum=constants.MAX_PORT_NUMBER), mandatory=True)
     connection_limit = wtypes.wsattr(
         wtypes.IntegerType(minimum=constants.MIN_CONNECTION_LIMIT),
@@ -208,7 +208,7 @@ class ListenerSingleCreate(BaseListenerType):
     protocol = wtypes.wsattr(wtypes.Enum(str, *constants.SUPPORTED_PROTOCOLS),
                              mandatory=True)
     protocol_port = wtypes.wsattr(
-        wtypes.IntegerType(minimum=constants.MIN_PORT_NUMBER,
+        wtypes.IntegerType(minimum=constants.MIN_PORT_NUMBER_LISTENER,
                            maximum=constants.MAX_PORT_NUMBER), mandatory=True)
     connection_limit = wtypes.wsattr(
         wtypes.IntegerType(minimum=constants.MIN_CONNECTION_LIMIT),

--- a/octavia/common/constants.py
+++ b/octavia/common/constants.py
@@ -241,6 +241,7 @@ ONLY_ESD_L7POLICY_PROTO = [PROTOCOL_PROXY, PROTOCOL_TCP, PROTOCOL_HTTPS]
 
 # API Integer Ranges
 MIN_PORT_NUMBER = 1
+MIN_PORT_NUMBER_LISTENER = 0  # A value of 0 means the listener receives on all ports. This is a F5 extension.
 MAX_PORT_NUMBER = 65535
 
 DEFAULT_CONNECTION_LIMIT = -1

--- a/octavia/tests/functional/api/v2/test_listener.py
+++ b/octavia/tests/functional/api/v2/test_listener.py
@@ -2109,6 +2109,23 @@ class TestListener(base.BaseAPITest):
         body = self._build_body(listener2_post)
         self.post(self.LISTENERS_PATH, body, status=201)
 
+    def test_create_allports_listener(self):
+        listener_post = {'protocol': constants.PROTOCOL_TCP,
+                         'protocol_port': 0,
+                         'loadbalancer_id': self.lb_id}
+        body = self._build_body(listener_post)
+        self.post(self.LISTENERS_PATH, body, status=201)
+
+    def test_create_allports_listener_multiple(self):
+        listener1 = self.create_listener(constants.PROTOCOL_TCP, 80,
+                                         self.lb_id)
+        self.set_lb_status(self.lb_id)
+        listener2_post = {'protocol': constants.PROTOCOL_TCP,
+                         'protocol_port': 0,
+                         'loadbalancer_id': self.lb_id}
+        body = self._build_body(listener2_post)
+        self.post(self.LISTENERS_PATH, body, status=400)
+
     def test_delete(self):
         listener = self.create_listener(constants.PROTOCOL_HTTP, 80,
                                         self.lb_id)


### PR DESCRIPTION
Unfortunately, ListenersController._validate_allports_listeners is not enough in the case of fully populated LBs. It can only check against listeners already existing in the DB. Therefore LoadBalancersController._validate_internal_listener_conflicts is needed as well.