### PR TITLE
Add listener/pool cipher allow list

### DIFF
--- a/octavia/api/v2/controllers/listener.py
+++ b/octavia/api/v2/controllers/listener.py
@@ -255,14 +255,20 @@ class ListenersController(base.BaseController):
                 "A client authentication CA reference is required to "
                 "specify a client authentication revocation list."))
 
-        # Check TLS cipher prohibit list
+        # Check TLS cipher prohibit list and allow list
         if 'tls_ciphers' in listener_dict and listener_dict['tls_ciphers']:
             rejected_ciphers = validate.check_cipher_prohibit_list(
                 listener_dict['tls_ciphers'])
+            rejected_ciphers.extend(validate.check_cipher_allow_list(
+                listener_dict['tls_ciphers']))
             if rejected_ciphers:
-                raise exceptions.ValidationException(detail=_(
-                    'The following ciphers have been prohibited by an '
-                    'administrator: ' + ', '.join(rejected_ciphers)))
+                detail = 'The following ciphers have been prohibited by an '\
+                         'administrator: ' + ', '.join(rejected_ciphers)
+                if CONF.api_settings.tls_cipher_allow_list is not None:
+                    detail += '. The following ciphers are allowed: '\
+                              + ', '.join(CONF.api_settings.tls_cipher_allow_list)
+                raise exceptions.ValidationException(detail=detail)
+
 
         # Validate the TLS containers
         sni_containers = listener_dict.pop('sni_containers', [])
@@ -547,14 +553,19 @@ class ListenersController(base.BaseController):
             self._validate_cidr_compatible_with_vip(
                 vip_address, listener.allowed_cidrs)
 
-        # Check TLS cipher prohibit list
+        # Check TLS cipher prohibit list and allow list
         if listener.tls_ciphers:
             rejected_ciphers = validate.check_cipher_prohibit_list(
                 listener.tls_ciphers)
+            rejected_ciphers.extend(validate.check_cipher_allow_list(
+                listener.tls_ciphers))
             if rejected_ciphers:
-                raise exceptions.ValidationException(detail=_(
-                    'The following ciphers have been prohibited by an '
-                    'administrator: ' + ', '.join(rejected_ciphers)))
+                detail = 'The following ciphers have been prohibited by an '\
+                         'administrator: ' + ', '.join(rejected_ciphers)
+                if CONF.api_settings.tls_cipher_allow_list is not None:
+                    detail += '. The following ciphers are allowed: '\
+                              + ', '.join(CONF.api_settings.tls_cipher_allow_list)
+                raise exceptions.ValidationException(detail=detail)
 
         if listener.tls_versions is not wtypes.Unset:
             # Validate TLS version list

--- a/octavia/api/v2/controllers/pool.py
+++ b/octavia/api/v2/controllers/pool.py
@@ -123,14 +123,19 @@ class PoolsController(base.BaseController):
                 pool_dict.get('ca_tls_certificate_id'),
                 pool_dict.get('crl_container_id', None))
 
-        # Check TLS cipher prohibit list
+        # Check TLS cipher prohibit list and allow list
         if 'tls_ciphers' in pool_dict and pool_dict['tls_ciphers']:
             rejected_ciphers = validate.check_cipher_prohibit_list(
                 pool_dict['tls_ciphers'])
+            rejected_ciphers.extend(validate.check_cipher_allow_list(
+                pool_dict['tls_ciphers']))
             if rejected_ciphers:
-                raise exceptions.ValidationException(detail=_(
-                    'The following ciphers have been prohibited by an '
-                    'administrator: ' + ', '.join(rejected_ciphers)))
+                detail = 'The following ciphers have been prohibited by an '\
+                         'administrator: ' + ', '.join(rejected_ciphers)
+                if CONF.api_settings.tls_cipher_allow_list is not None:
+                    detail += '. The following ciphers are allowed: '\
+                              + ', '.join(CONF.api_settings.tls_cipher_allow_list)
+                raise exceptions.ValidationException(detail=detail)
 
         if pool_dict['tls_enabled']:
             # Validate TLS version list
@@ -412,14 +417,19 @@ class PoolsController(base.BaseController):
         if ca_ref:
             self._validate_client_ca_and_crl_refs(ca_ref, crl_ref)
 
-        # Check TLS cipher prohibit list
+        # Check TLS cipher prohibit list and allow list
         if pool.tls_ciphers:
             rejected_ciphers = validate.check_cipher_prohibit_list(
                 pool.tls_ciphers)
+            rejected_ciphers.extend(validate.check_cipher_allow_list(
+                pool.tls_ciphers))
             if rejected_ciphers:
-                raise exceptions.ValidationException(detail=_(
-                    "The following ciphers have been prohibited by an "
-                    "administrator: " + ', '.join(rejected_ciphers)))
+                detail = 'The following ciphers have been prohibited by an '\
+                         'administrator: ' + ', '.join(rejected_ciphers)
+                if CONF.api_settings.tls_cipher_allow_list is not None:
+                    detail += '. The following ciphers are allowed: '\
+                              + ', '.join(CONF.api_settings.tls_cipher_allow_list)
+                raise exceptions.ValidationException(detail=detail)
 
         if pool.tls_versions is not wtypes.Unset:
             # Validate TLS version list

--- a/octavia/common/config.py
+++ b/octavia/common/config.py
@@ -123,6 +123,10 @@ api_opts = [
                deprecated_name='tls_cipher_blacklist',
                help=_("Colon separated list of OpenSSL ciphers. "
                       "Usage of these ciphers will be blocked.")),
+    cfg.StrOpt('tls_cipher_allow_list', default=None,
+               help=_("Colon separated list of OpenSSL ciphers (cipher suites). "
+                      "Usage of all other ciphers will be blocked."
+                      "If unset, ciphers are checked only against tls_cipher_prohibit_list.")),
     cfg.ListOpt('default_listener_tls_versions',
                 default=constants.TLS_VERSIONS_OWASP_SUITE_B,
                 help=_('List of TLS versions to use for new TLS-enabled '
@@ -954,7 +958,7 @@ def init(args, **kwargs):
              **kwargs)
     validate.check_default_tls_versions_min_conflict()
     setup_remote_debugger()
-    validate.check_default_ciphers_prohibit_list_conflict()
+    validate.check_default_ciphers_conflict()
 
 
 def setup_logging(conf):

--- a/octavia/common/validate.py
+++ b/octavia/common/validate.py
@@ -431,6 +431,8 @@ def ip_not_reserved(ip_address):
 
 
 def check_cipher_prohibit_list(cipherstring):
+    if cipherstring == '':
+        return []
     ciphers = cipherstring.split(':')
     prohibit_list = CONF.api_settings.tls_cipher_prohibit_list.split(':')
     rejected = []
@@ -440,7 +442,19 @@ def check_cipher_prohibit_list(cipherstring):
     return rejected
 
 
-def check_default_ciphers_prohibit_list_conflict():
+def check_cipher_allow_list(cipherstring):
+    if cipherstring == '' or CONF.api_settings.tls_cipher_allow_list is None:
+        return []
+    ciphers = cipherstring.split(':')
+    allow_list = CONF.api_settings.tls_cipher_allow_list.split(':')
+    rejected = []
+    for cipher in ciphers:
+        if cipher not in allow_list:
+            rejected.append(cipher)
+    return rejected
+
+
+def check_default_ciphers_conflict():
     listener_rejected = check_cipher_prohibit_list(
         CONF.api_settings.default_listener_ciphers)
     if listener_rejected:
@@ -448,12 +462,28 @@ def check_default_ciphers_prohibit_list_conflict():
             detail=_('Default listener ciphers conflict with prohibit list. '
                      'Conflicting ciphers: ' + ', '.join(listener_rejected)))
 
+    listener_rejected = check_cipher_allow_list(
+        CONF.api_settings.default_listener_ciphers)
+    if listener_rejected:
+        raise exceptions.ValidationException(
+            detail=_('Default listener ciphers contain ciphers not in allow list. '
+                     'Disallowed ciphers: ' + ', '.join(listener_rejected) +
+                     'Allowed ciphers: ' + CONF.api_settings.tls_cipher_allow_list))
+
     pool_rejected = check_cipher_prohibit_list(
         CONF.api_settings.default_pool_ciphers)
     if pool_rejected:
         raise exceptions.ValidationException(
             detail=_('Default pool ciphers conflict with prohibit list. '
                      'Conflicting ciphers: ' + ', '.join(pool_rejected)))
+
+    pool_rejected = check_cipher_allow_list(
+        CONF.api_settings.default_pool_ciphers)
+    if pool_rejected:
+        raise exceptions.ValidationException(
+            detail=_('Default pool ciphers contain ciphers not in allow list. '
+                     'Disallowed ciphers: ' + ', '.join(pool_rejected) +
+                     'Allowed ciphers: ' + CONF.api_settings.tls_cipher_allow_list))
 
 
 def check_tls_version_list(versions):

--- a/octavia/common/validate.py
+++ b/octavia/common/validate.py
@@ -431,7 +431,7 @@ def ip_not_reserved(ip_address):
 
 
 def check_cipher_prohibit_list(cipherstring):
-    if cipherstring == '':
+    if not CONF.api_settings.tls_cipher_prohibit_list:
         return []
     ciphers = cipherstring.split(':')
     prohibit_list = CONF.api_settings.tls_cipher_prohibit_list.split(':')
@@ -443,7 +443,7 @@ def check_cipher_prohibit_list(cipherstring):
 
 
 def check_cipher_allow_list(cipherstring):
-    if cipherstring == '' or CONF.api_settings.tls_cipher_allow_list is None:
+    if not CONF.api_settings.tls_cipher_allow_list:
         return []
     ciphers = cipherstring.split(':')
     allow_list = CONF.api_settings.tls_cipher_allow_list.split(':')

--- a/octavia/tests/unit/common/test_validate.py
+++ b/octavia/tests/unit/common/test_validate.py
@@ -470,7 +470,7 @@ class TestValidations(base.TestCase):
 
         self.assertRaises(
             exceptions.ValidationException,
-            validate.check_default_ciphers_prohibit_list_conflict)
+            validate.check_default_ciphers_conflict)
 
     def test_check_default_ciphers_allow_list_conflict(self):
         self.conf.config(group='api_settings',
@@ -484,7 +484,7 @@ class TestValidations(base.TestCase):
         self.conf.config(group='api_settings', default_pool_ciphers='')
         self.assertRaises(
             exceptions.ValidationException,
-            validate.check_default_ciphers_prohibit_list_conflict)
+            validate.check_default_ciphers_conflict)
 
         # default pool ciphers conflict
         self.conf.config(group='api_settings', default_listener_ciphers='')
@@ -493,7 +493,7 @@ class TestValidations(base.TestCase):
                          'PSK-AES128-CBC-SHA:TLS_AES_256_GCM_SHA384')
         self.assertRaises(
             exceptions.ValidationException,
-            validate.check_default_ciphers_prohibit_list_conflict)
+            validate.check_default_ciphers_conflict)
 
     def test_check_default_ciphers_allow_list_no_conflict(self):
         self.conf.config(group='api_settings',
@@ -508,7 +508,7 @@ class TestValidations(base.TestCase):
         self.conf.config(group='api_settings',
                          default_pool_ciphers=
                          'PSK-AES128-CBC-SHA:TLS_AES_256_GCM_SHA384')
-        self.assertTrue(validate.check_default_ciphers_prohibit_list_conflict() is None)
+        self.assertTrue(validate.check_default_ciphers_conflict() is None)
 
     def test_check_tls_version_list(self):
         # Test valid list

--- a/octavia/tests/unit/common/test_validate.py
+++ b/octavia/tests/unit/common/test_validate.py
@@ -461,6 +461,7 @@ class TestValidations(base.TestCase):
                           '2001:0DB8::5')
 
     def test_check_default_ciphers_prohibit_list_conflict(self):
+        self.conf.config(group='api_settings', tls_cipher_allow_list=None)
         self.conf.config(group='api_settings',
                          tls_cipher_prohibit_list='PSK-AES128-CBC-SHA')
         self.conf.config(group='api_settings',
@@ -470,6 +471,44 @@ class TestValidations(base.TestCase):
         self.assertRaises(
             exceptions.ValidationException,
             validate.check_default_ciphers_prohibit_list_conflict)
+
+    def test_check_default_ciphers_allow_list_conflict(self):
+        self.conf.config(group='api_settings',
+                         tls_cipher_allow_list='PSK-AES128-CBC-SHA')
+        self.conf.config(group='api_settings', tls_cipher_prohibit_list='')
+
+        # default listener ciphers conflict
+        self.conf.config(group='api_settings',
+                         default_listener_ciphers='ECDHE-ECDSA-AES256-SHA:'
+                         'PSK-AES128-CBC-SHA:TLS_AES_256_GCM_SHA384')
+        self.conf.config(group='api_settings', default_pool_ciphers='')
+        self.assertRaises(
+            exceptions.ValidationException,
+            validate.check_default_ciphers_prohibit_list_conflict)
+
+        # default pool ciphers conflict
+        self.conf.config(group='api_settings', default_listener_ciphers='')
+        self.conf.config(group='api_settings',
+                         default_pool_ciphers='ECDHE-ECDSA-AES256-SHA:'
+                         'PSK-AES128-CBC-SHA:TLS_AES_256_GCM_SHA384')
+        self.assertRaises(
+            exceptions.ValidationException,
+            validate.check_default_ciphers_prohibit_list_conflict)
+
+    def test_check_default_ciphers_allow_list_no_conflict(self):
+        self.conf.config(group='api_settings',
+                         tls_cipher_allow_list='PSK-AES128-CBC-SHA:'
+                         'ECDHE-ECDSA-AES256-SHA:TLS_AES_256_GCM_SHA384')
+        self.conf.config(group='api_settings',
+                         tls_cipher_prohibit_list='')
+
+        self.conf.config(group='api_settings',
+                         default_listener_ciphers=
+                         'ECDHE-ECDSA-AES256-SHA:TLS_AES_256_GCM_SHA384')
+        self.conf.config(group='api_settings',
+                         default_pool_ciphers=
+                         'PSK-AES128-CBC-SHA:TLS_AES_256_GCM_SHA384')
+        self.assertTrue(validate.check_default_ciphers_prohibit_list_conflict() is None)
 
     def test_check_tls_version_list(self):
         # Test valid list


### PR DESCRIPTION
- Add unit tests for listener/pool ciphers allow list
- Add `tls_cipher_allow_list` config option
- If the allow list is not set (`None`), only the prohibit list is enforced
- If there is a cipher conflict, tell the API user the cipher allow list, if it is set
- Fix `check_cipher_prohibit_list`: If prohibit list is empty, return immediately. Else there will be a false positive cipher conflict if `cipherstring.split(':')` contains `''`.
- Rename `check_default_ciphers_prohibit_list_conflict` to `check_default_ciphers_conflict`
- Extend `check_default_ciphers_conflict` to check for ciphers not in allow list.