### PR TITLE
barbican fallback to legacy only if not found

### DIFF
--- a/octavia/certificates/manager/barbican.py
+++ b/octavia/certificates/manager/barbican.py
@@ -115,7 +115,10 @@ class BarbicanCertManager(cert_mgr.CertManager):
             return pkcs12.PKCS12Cert(cert_secret.payload)
         except exceptions.UnreadablePKCS12:
             raise
-        except Exception:
+        except Exception as e:
+            LOG.warning('Failed to load PKCS12Cert for secret %s with %s',
+                        cert_ref, str(e))
+            LOG.warning('Falling back to the barbican_legacy implementation.')
             # If our get fails, try with the legacy driver.
             # TODO(rm_work): Remove this code when the deprecation cycle for
             # the legacy driver is complete.

--- a/octavia/certificates/manager/barbican.py
+++ b/octavia/certificates/manager/barbican.py
@@ -19,6 +19,7 @@ Cert manager implementation for Barbican using a single PKCS12 secret
 """
 from OpenSSL import crypto
 
+from barbicanclient import exceptions as barbican_exceptions
 from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_utils import encodeutils
@@ -115,7 +116,12 @@ class BarbicanCertManager(cert_mgr.CertManager):
             return pkcs12.PKCS12Cert(cert_secret.payload)
         except exceptions.UnreadablePKCS12:
             raise
-        except Exception as e:
+        except barbican_exceptions.HTTPClientError as e:
+            # we only want to try the legacy (container) based retrieval if the pkcs12 cert is not found,
+            # else, just raise the error so we retry the pkcs12 retrieval again
+            if e.status_code != 404:
+                raise
+
             LOG.warning('Failed to load PKCS12Cert for secret %s with %s',
                         cert_ref, str(e))
             LOG.warning('Falling back to the barbican_legacy implementation.')


### PR DESCRIPTION
- **When we failed to load pkcs12 cert print warning**
- **barbican: only fallback to legacy secret container when missing pkcs12**

This PR changes the behavior of the upstream barbican cert mechanism.
The code used to try first to fetch the certificate as a barbican pkcs12 secret,
and if any exception happened to try fetch the certifcate from a barbican container.

The octavia-f5-driver used the 404 message as a hint that the cert was missing or expired. But this
was shadowed by any connection error that the pkcs12 barbican code was encountered, even if there
is a valid pkcs12 certificate.

This change will do the fallback to legacy containers only if the pkcs12 retrieval fails with 404 (not found).

Therefor, octavia-f5-driver can correctly act on a missing certificate
