### PR TITLE
Backport 1e861fd - Fix barbican client with application credentials/trusts

### DIFF
--- a/octavia/tests/unit/certificates/common/auth/test_barbican_acl.py
+++ b/octavia/tests/unit/certificates/common/auth/test_barbican_acl.py
@@ -91,5 +91,4 @@ class TestBarbicanACLAuth(base.TestCase):
         bc = acl_auth_object.get_barbican_client_user_auth(mock.Mock())
         self.assertTrue(hasattr(bc, 'containers') and
                         hasattr(bc.containers, 'register_consumer'))
-        self.assertEqual('publicURL', bc.client.interface)
-        self.assertEqual('RegionOne', bc.client.region_name)
+        self.assertEqual('public', bc.client.interface)


### PR DESCRIPTION
Using application credentials for authentication makes Barbican certificate fetching fail. Backport the fixing commit 1e861fd1d8ee58c17ae52d4fe59dff8f78b34426

See https://opendev.org/openstack/octavia/commit/1e861fd1d8ee58c17ae52d4fe59dff8f78b34426