### PR TITLE
tox: Use sapcc custom upper-constraints.txt

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv = VIRTUAL_ENV={envdir}
 install_command =
     pip install {opts} {packages}
 allowlist_externals = find
-deps = -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/yoga}
+deps = -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/refs/heads/stable/yoga-m3/upper-constraints.txt}
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =


### PR DESCRIPTION
Due to custom changes like e. g. https://github.com/sapcc/requirements/pull/96