### PR TITLE
Add ALPN -> Listener protocol combinations checks

### DIFF
--- a/octavia/api/v2/controllers/listener.py
+++ b/octavia/api/v2/controllers/listener.py
@@ -334,7 +334,7 @@ class ListenersController(base.BaseController):
             validate.check_alpn_protocols(listener_dict['alpn_protocols'])
 
         validate.check_alpn_protocols_and_listener_protocol_conflicts(
-            listener_dict['alpn_protocols'], _can_tls_offload)
+            listener_dict.get('alpn_protocols', []), _can_tls_offload)
 
         try:
             db_listener = self.repositories.listener.create(

--- a/octavia/api/v2/controllers/listener.py
+++ b/octavia/api/v2/controllers/listener.py
@@ -333,6 +333,9 @@ class ListenersController(base.BaseController):
             # Validate ALPN protocol list
             validate.check_alpn_protocols(listener_dict['alpn_protocols'])
 
+        validate.check_alpn_protocols_and_listener_protocol_conflicts(
+            listener_dict['alpn_protocols'], _can_tls_offload)
+
         try:
             db_listener = self.repositories.listener.create(
                 lock_session, **listener_dict)
@@ -576,6 +579,9 @@ class ListenersController(base.BaseController):
         if listener.alpn_protocols is not wtypes.Unset:
             # Validate ALPN protocol list
             validate.check_alpn_protocols(listener.alpn_protocols)
+            # Validate ALPN conflicts with listener protocols
+            validate.check_alpn_protocols_and_listener_protocol_conflicts(
+                listener.alpn_protocols, _can_tls_offload)
 
     def _set_default_on_none(self, listener):
         """Reset settings to their default values if None/null was passed in

--- a/octavia/common/validate.py
+++ b/octavia/common/validate.py
@@ -31,6 +31,7 @@ from octavia.common import constants
 from octavia.common import exceptions
 from octavia.common import utils
 from octavia.i18n import _
+from octavia_lib.common import constants as lib_consts
 
 CONF = cfg.CONF
 
@@ -556,3 +557,14 @@ def check_alpn_protocols(protocols):
     if invalid_protocols:
         raise exceptions.ValidationException(
             detail=_('Invalid ALPN protocol: ' + ', '.join(invalid_protocols)))
+
+
+def check_alpn_protocols_and_listener_protocol_conflicts(alpn,
+                                                         listener_with_tls):
+    if not alpn:
+        return
+
+    if lib_consts.ALPN_PROTOCOL_HTTP_2 in alpn and not listener_with_tls:
+        raise exceptions.ValidationException(
+            detail=_('ALPN protocol "h2" cannot be used with non HTTPs '
+                     'listeners'))

--- a/octavia/tests/functional/api/v2/test_listener.py
+++ b/octavia/tests/functional/api/v2/test_listener.py
@@ -2507,6 +2507,22 @@ class TestListener(base.BaseAPITest):
 
     # TODO(johnsom) Fix this when there is a noop certificate manager
     @mock.patch('octavia.common.tls_utils.cert_parser.load_certificates_data')
+    def test_create_with_alpn_and_conflict_protocol(self, mock_cert_data):
+        req_dict = {'protocol': constants.PROTOCOL_HTTP,
+                    'protocol_port': 80,
+                    'loadbalancer_id': self.lb_id,
+                    'alpn_protocols': [lib_consts.ALPN_PROTOCOL_HTTP_1_1,
+                                       lib_consts.ALPN_PROTOCOL_HTTP_2]}
+        res = self.post(self.LISTENERS_PATH, self._build_body(req_dict),
+                        status=400)
+        fault = res.json['faultstring']
+        self.assertIn(
+            'Validation failure: ALPN protocol "h2" cannot be used with '
+            'non HTTPs listeners', fault)
+        self.assert_correct_status(lb_id=self.lb_id)
+
+    # TODO(johnsom) Fix this when there is a noop certificate manager
+    @mock.patch('octavia.common.tls_utils.cert_parser.load_certificates_data')
     def test_create_with_alpn_negative(self, mock_cert_data):
         cert1 = data_models.TLSContainer(certificate='cert 1')
         mock_cert_data.return_value = {'tls_cert': cert1}


### PR DESCRIPTION
This PR adds conflict checks for ALPN protocols and Listener protocols combinations.

This change was tested in QA:

Trying to apply `h2` ALPN protocol to `HTTP` listener:
```
$ openstack loadbalancer listener show b96cdab3-b65a-4993-b105-8b03c0e0e1e0 -c alpn_protocols
+----------------+--------------------------+
| Field          | Value                    |
+----------------+--------------------------+
| alpn_protocols | ['http/1.1', 'http/1.0'] |
+----------------+--------------------------+

$ openstack loadbalancer  listener set --alpn-protocol "http/1.1" --alpn-protocol "h2" b96cdab3-b65a-4993-b105-8b03c0e0e1e0
Validation failure: ALPN protocol "h2" cannot be used with non HTTPs listeners (HTTP 400) (Request-ID: req-949ea9d8-7f0b-4574-bcde-afba62469eac)

$ openstack loadbalancer listener show b96cdab3-b65a-4993-b105-8b03c0e0e1e0 -c alpn_protocols
+----------------+--------------------------+
| Field          | Value                    |
+----------------+--------------------------+
| alpn_protocols | ['http/1.1', 'http/1.0'] |
+----------------+--------------------------+
```

Trying to apply `h2` ALPN protocol to `TERMINATED_HTTPS` listener:
```
$ openstack loadbalancer  listener set --alpn-protocol "http/1.1" --alpn-protocol "http/1.0" --alpn-protocol "h2" 395f9766-1dd5-42ae-bd42-742f4cb9da35

$ openstack loadbalancer listener show 395f9766-1dd5-42ae-bd42-742f4cb9da35 -c alpn_protocols
+----------------+--------------------------------+
| Field          | Value                          |
+----------------+--------------------------------+
| alpn_protocols | ['http/1.1', 'http/1.0', 'h2'] |
+----------------+--------------------------------+
```