### PR TITLE
Fix conditions for checks at listener PUT request

### DIFF
--- a/octavia/api/v2/controllers/listener.py
+++ b/octavia/api/v2/controllers/listener.py
@@ -569,13 +569,13 @@ class ListenersController(base.BaseController):
                               + CONF.api_settings.tls_cipher_allow_list
                 raise exceptions.ValidationException(detail=detail)
 
-        if listener.tls_versions is not wtypes.Unset:
+        if (listener.tls_versions and listener.tls_versions != wtypes.Unset):
             # Validate TLS version list
             validate.check_tls_version_list(listener.tls_versions)
             # Validate TLS versions against minimum
             validate.check_tls_version_min(listener.tls_versions)
 
-        if listener.alpn_protocols is not wtypes.Unset:
+        if (listener.alpn_protocols and listener.alpn_protocols != wtypes.Unset):
             # Validate ALPN protocol list
             validate.check_alpn_protocols(listener.alpn_protocols)
             # Validate ALPN conflicts with listener protocols


### PR DESCRIPTION
Change the conditions to the same form as the conditions for the other checks further above in the function.

- [x] However, now the TLS versions are set to a default value instead of no values => This is [expected behavior](https://github.com/sapcc/octavia/blob/stable/yoga-m3/octavia/api/v2/controllers/listener.py#L614-L616) (see function docstring), won't fix.

Fixes #48