### PR TITLE
Fix rate-limit middleware config error

### DIFF
--- a/octavia/common/config.py
+++ b/octavia/common/config.py
@@ -944,6 +944,9 @@ watcher_opts = [
 ]
 
 rate_limit_opts = [
+    cfg.BoolOpt('enabled',
+                default=False,
+                help=_('Enable the openstack-rate-limit-middleware')),
     cfg.StrOpt('config_file', default="/etc/octavia/ratelimit.yaml",
                help=_('Path to the rate limiting middleware configuration file')),
     cfg.StrOpt('service_type', default="loadbalancer",


### PR DESCRIPTION
This PR fixes configurariotn parser error for rate-limit middleware:
```
 mod_wsgi (pid=18): Failed to exec Python script file '/var/lib/openstack/bin/octavia-wsgi'.
 mod_wsgi (pid=18): Exception occurred processing WSGI script '/var/lib/openstack/bin/octavia-wsgi'.
 Traceback (most recent call last):
   File "/var/lib/openstack/bin/octavia-wsgi", line 52, in <module>
     application = setup_app()
                   ^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/octavia/api/app.py", line 83, in setup_app
     return pecan_make_app(
            ^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/pecan/__init__.py", line 91, in make_app
     app = wrap_app(app)
           ^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/octavia/api/app.py", line 147, in _wrap_app
     if rate_limit_errors and rate_limit_middleware and CONF.rate_limit.enabled:
                                                        ^^^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_config/cfg.py", line 3377, in __getattr__
     return self._conf._get(name, self._group)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_config/cfg.py", line 2868, in _get
     value, loc = self._do_get(name, group, namespace)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_config/cfg.py", line 2886, in _do_get
     info = self._get_opt_info(name, group)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_config/cfg.py", line 3091, in _get_opt_info
     raise NoSuchOptError(opt_name, group)
 oslo_config.cfg.NoSuchOptError: no such option enabled in group [rate_limit]
```