### PR TITLE
Fix Middleware configuration for rate-limit

### DIFF
--- a/octavia/api/app.py
+++ b/octavia/api/app.py
@@ -115,6 +115,8 @@ def _wrap_app(app):
             )
 
     # sapcc/openstack-rate-limit-middleware
+    # rate-limit uses variables from watcher, so it should be running after
+    # watcher middleware, it means here it should be earlier
     if rate_limit_errors and rate_limit_middleware and CONF.rate_limit.enabled:
         LOG.info("openstack-rate-limit-middleware activated")
         try:

--- a/octavia/api/app.py
+++ b/octavia/api/app.py
@@ -114,6 +114,31 @@ def _wrap_app(app):
                 reason=e
             )
 
+    # sapcc/openstack-rate-limit-middleware
+    if rate_limit_errors and rate_limit_middleware and CONF.rate_limit.enabled:
+        LOG.info("openstack-rate-limit-middleware activated")
+        try:
+            app = rate_limit_middleware.OpenStackRateLimitMiddleware(
+                app,
+                config_file=CONF.rate_limit.config_file,
+                clock_accuracy=CONF.rate_limit.clock_accuracy,
+                service_type=CONF.rate_limit.service_type,
+                rate_limit_by=CONF.rate_limit.rate_limit_by,
+                max_sleep_time_seconds=CONF.rate_limit.max_sleep_time_seconds,
+                log_sleep_time_seconds=CONF.rate_limit.log_sleep_time_seconds,
+                backend_host=CONF.rate_limit.backend_host,
+                backend_port=CONF.rate_limit.backend_port,
+                backend_secret_file=CONF.rate_limit.backend_secret_file,
+                backend_max_connections=CONF.rate_limit.backend_max_connections,
+                backend_timeout_seconds=CONF.rate_limit.backend_timeout_seconds
+            )
+        except (EnvironmentError, OSError,
+                rate_limit_errors.ConfigError) as e:
+            raise exceptions.InputFileError(
+                file_name=CONF.rate_limit.config_file,
+                reason=e
+            )
+
     # sapcc/openstack-watcher-middleware
     if watcher_errors and watcher_middleware and CONF.watcher.enabled:
         LOG.info("Openstack-Watcher-Middleware activated")
@@ -143,20 +168,6 @@ def _wrap_app(app):
         profiler_factory = profiler_web.WsgiMiddleware.factory(None, hmac_keys=CONF.profiler.hmac_keys, enabled=True)
         app = profiler_factory(app)
 
-    # sapcc/openstack-rate-limit-middleware
-    if rate_limit_errors and rate_limit_middleware and CONF.rate_limit.enabled:
-        LOG.info("openstack-rate-limit-middleware activated")
-        try:
-            app = rate_limit_middleware.OpenStackRateLimitMiddleware(
-                app,
-                config=dict(CONF.rate_limit)
-            )
-        except (EnvironmentError, OSError,
-                rate_limit_errors.ConfigError) as e:
-            raise exceptions.InputFileError(
-                file_name=CONF.rate_limit.config_file,
-                reason=e
-            )
 
     if cfg.CONF.api_settings.auth_strategy == constants.KEYSTONE:
         app = keystone.SkippingAuthProtocol(app, {})

--- a/octavia/common/config.py
+++ b/octavia/common/config.py
@@ -944,10 +944,19 @@ watcher_opts = [
 ]
 
 rate_limit_opts = [
-    cfg.StrOpt('config_file', default="/etc/octavia/ratelimit.yaml",
-               help=_('Path to the rate limiting middleware configuration file')),
+    cfg.BoolOpt('enabled',
+                default=False,
+                help=_('Enable the openstack-rate-limit-middleware')),
     cfg.StrOpt('service_type', default="loadbalancer",
                help=_('The service type according to CADF specification')),
+    cfg.StrOpt('config_file', default="/etc/octavia/ratelimit.yaml",
+               help=_('Path to the rate limiting middleware configuration file')),
+    cfg.StrOpt('clock_accuracy', default="1ns",
+               help=_('If this middleware enforces rate limits in multiple replicas of an API,'
+                      'the clock accuracy of the individual replicas can be configured as follows.'
+                      'Especially in high-load scenarios, involving a sign. number of concurrent '
+                      'requests, choosing nanosecond accuracy is advised - given support by OS and '
+                      'clock.')),
     cfg.StrOpt('rate_limit_by',
                help=_('Per default rate limits are applied based on '
                       '`initiator_project_id`. However, this can also be se to '
@@ -958,10 +967,15 @@ rate_limit_opts = [
                       'a request can be suspended until the specified maximum '
                       'duration to fit the configured rate limit. This feature '
                       'can be disabled by setting the max sleep time to 0 seconds.')),
+    cfg.IntOpt('log_sleep_time_seconds', default=10,
+               help=_('Log requests that are going to be suspended for '
+                      'log_sleep_time_seconds <= t <= max_sleep_time_seconds.')),
     cfg.StrOpt('backend_host', default="127.0.0.1",
                help=_('Redis backend host for rate limiting middleware')),
     cfg.PortOpt('backend_port', default=6379,
                 help=_('Redis backend port for rate limiting middleware')),
+    cfg.StrOpt('backend_secret_file', default='',
+                help=_('Password for redis backend stored in a file')),
     cfg.IntOpt('backend_max_connections', default=100,
                help=_('Maximum connections for redis connection pool.')),
     cfg.IntOpt('backend_timeout_seconds', default=2,


### PR DESCRIPTION
This PR fixes configuration pasing to rate-limit middleware:
- fix order for middlewares ([rate-limit uses variables](https://github.com/sapcc/openstack-rate-limit-middleware/blob/611c80303bfd9b295cf8b2d35ddedee85338d477/rate_limit/rate_limit.py#L476) from watcher so it should be running AFTER watcher)
- fix config arguments passing (middleware expects arguments not dict)
- add all config variables required for rate-limit middleware