### PR TITLE
Security Groups F5 driver implementation

### DIFF
--- a/octavia/common/rpc.py
+++ b/octavia/common/rpc.py
@@ -74,3 +74,16 @@ def get_notifier(service=None, host=None, publisher_id=None):
 
 def create_transport(url):
     return messaging.get_rpc_transport(cfg.CONF, url=url)
+
+
+def get_notification_listener(targets, endpoints, serializer=None):
+    if NOTIFICATION_TRANSPORT is None:
+        raise AssertionError("'NOTIFICATION_TRANSPORT' must not be None")
+    if serializer is None:
+        serializer = messaging.NoOpSerializer()
+    return messaging.get_notification_listener(
+        NOTIFICATION_TRANSPORT,
+        targets,
+        endpoints,
+        serializer=serializer
+    )

--- a/octavia/common/rpc.py
+++ b/octavia/common/rpc.py
@@ -77,8 +77,7 @@ def create_transport(url):
 
 
 def get_notification_listener(targets, endpoints, serializer=None):
-    if NOTIFICATION_TRANSPORT is None:
-        raise AssertionError("'NOTIFICATION_TRANSPORT' must not be None")
+    assert NOTIFICATION_TRANSPORT, "NOTIFICATION_TRANSPORT must not be None"
     if serializer is None:
         serializer = messaging.NoOpSerializer()
     return messaging.get_notification_listener(

--- a/octavia/controller/queue/v2/consumer.py
+++ b/octavia/controller/queue/v2/consumer.py
@@ -38,6 +38,7 @@ class ConsumerService(cotyledon.Service):
         self.endpoints = []
         self.access_policy = dispatcher.DefaultRPCAccessPolicy
         self.message_listener = None
+        self.notification_listener = None
 
     def run(self):
         LOG.info('Starting V2 consumer...')
@@ -50,6 +51,14 @@ class ConsumerService(cotyledon.Service):
             access_policy=self.access_policy
         )
         self.message_listener.start()
+
+        LOG.info('Starting Notification Listener...')
+        self.notification_listener = rpc.get_notification_listener(
+            targets=[messaging.Target(topic='notifications')],
+            endpoints=[endpoints.NotificationEndpoints()]
+        )
+        self.notification_listener.start()
+
         if CONF.task_flow.jobboard_enabled:
             for e in self.endpoints:
                 e.worker.services_controller.run_conductor(
@@ -63,6 +72,10 @@ class ConsumerService(cotyledon.Service):
             LOG.info('V2 Consumer successfully stopped.  Waiting for '
                      'final messages to be processed...')
             self.message_listener.wait()
+        if self.notification_listener:
+            LOG.info('Stopping Notification Listener...')
+            self.notification_listener.stop()
+            LOG.info('Notification listener successfully stopped.')
         if self.endpoints:
             LOG.info('Shutting down V2 endpoint worker executors...')
             for e in self.endpoints:

--- a/octavia/controller/queue/v2/consumer.py
+++ b/octavia/controller/queue/v2/consumer.py
@@ -55,7 +55,7 @@ class ConsumerService(cotyledon.Service):
         LOG.info('Starting Notification Listener...')
         self.notification_listener = rpc.get_notification_listener(
             targets=[messaging.Target(topic='notifications')],
-            endpoints=[endpoints.NotificationEndpoints()]
+            endpoints=[endpoints.NetworkingF5NotificationsEndpoint()]
         )
         self.notification_listener.start()
 

--- a/octavia/controller/queue/v2/endpoints.py
+++ b/octavia/controller/queue/v2/endpoints.py
@@ -188,19 +188,17 @@ class Endpoints:
         self.worker.delete_amphora(amphora_id)
 
 
-class NotificationEndpoints(object):
+class NetworkingF5NotificationsEndpoint(object):
 
     filter_rule = messaging.NotificationFilter(
         publisher_id='^networking_f5.*')
 
     def __init__(self):
-        # self.plugin = stevedore_driver.DriverManager(
-        #     namespace='octavia.plugins.notifications',
-        #     name=CONF.octavia_plugins,
-        #     invoke_on_load=True
-        # ).driver
-        from octavia_f5.controller.worker.controller_worker import ControllerWorkerNotifications
-        self.plugin = ControllerWorkerNotifications()
+        self.plugin = stevedore_driver.DriverManager(
+            namespace='octavia.plugins.notifications',
+            name=CONF.octavia_plugins,
+            invoke_on_load=True
+        ).driver
 
     def info(self, ctxt, publisher_id, event_type, payload, metadata):
         LOG.debug("Got notification from publisher %s with event %s and payload %s",

--- a/octavia/controller/queue/v2/endpoints.py
+++ b/octavia/controller/queue/v2/endpoints.py
@@ -186,3 +186,25 @@ class Endpoints:
     def delete_amphora(self, context, amphora_id):
         LOG.info('Deleting amphora \'%s\'...', amphora_id)
         self.worker.delete_amphora(amphora_id)
+
+
+class NotificationEndpoints(object):
+
+    filter_rule = messaging.NotificationFilter(
+        publisher_id='^networking_f5.*')
+
+    def __init__(self):
+        # self.plugin = stevedore_driver.DriverManager(
+        #     namespace='octavia.plugins.notifications',
+        #     name=CONF.octavia_plugins,
+        #     invoke_on_load=True
+        # ).driver
+        from octavia_f5.controller.worker.controller_worker import ControllerWorkerNotifications
+        self.plugin = ControllerWorkerNotifications()
+
+    def info(self, ctxt, publisher_id, event_type, payload, metadata):
+        LOG.debug("Got notification from publisher %s with event %s and payload %s",
+                  publisher_id, event_type, payload)
+        _, action = event_type.split('.')
+        self.plugin.process_security_group_update_notification(
+            security_group_id=payload['security_group_id'], action=action)

--- a/octavia/tests/unit/controller/queue/v2/test_consumer.py
+++ b/octavia/tests/unit/controller/queue/v2/test_consumer.py
@@ -31,10 +31,11 @@ class TestConsumer(base.TestRpc):
         conf.config(host='test-hostname')
         self.conf = conf.conf
 
+    @mock.patch('stevedore.driver.DriverManager', return_value=mock.MagicMock())
     @mock.patch.object(messaging, 'Target')
     @mock.patch.object(endpoints, 'Endpoints')
     @mock.patch.object(messaging, 'get_rpc_server')
-    def test_consumer_run(self, mock_rpc_server, mock_endpoint, mock_target):
+    def test_consumer_run(self, mock_rpc_server, mock_endpoint, mock_target, mock_driver):
         mock_rpc_server_rv = mock.Mock()
         mock_rpc_server.return_value = mock_rpc_server_rv
         mock_endpoint_rv = mock.Mock()
@@ -44,14 +45,16 @@ class TestConsumer(base.TestRpc):
 
         consumer.ConsumerService(1, self.conf).run()
 
-        mock_target.assert_called_once_with(topic=constants.TOPIC_AMPHORA_V2,
-                                            server='test-hostname',
-                                            fanout=False)
+        calls = [mock.call(topic='octavia_provisioning_v2', server='test-hostname', fanout=False),
+                 mock.call(topic='notifications')]
+        self.assertEqual(calls[0], mock_target.mock_calls[0])
+        self.assertEqual(calls[1], mock_target.mock_calls[1])
         mock_endpoint.assert_called_once_with()
 
+    @mock.patch('stevedore.driver.DriverManager', return_value=mock.MagicMock())
     @mock.patch.object(messaging, 'get_rpc_server')
     @mock.patch.object(endpoints, 'Endpoints')
-    def test_consumer_terminate(self, mock_endpoint, mock_rpc_server):
+    def test_consumer_terminate(self, mock_endpoint, mock_rpc_server, mock_driver):
         mock_rpc_server_rv = mock.Mock()
         mock_rpc_server.return_value = mock_rpc_server_rv
 


### PR DESCRIPTION
This PR contains the Consumer and Notification listener part for the Octavia F5 driver. The listener will be initialized during Octavia Worker start and uses handlers from `octavia.plugins.notifications` entrypoint.

Related PRs:
1. https://github.com/sapcc/octavia-f5-provider-driver/pull/319
2. https://github.com/sapcc/networking-f5/pull/6
3. https://github.com/sapcc/helm-charts/pull/10176
