### PR TITLE
Add cross-pool batch member update feature (CPBMU)

### DIFF
--- a/octavia/api/v2/controllers/member.py
+++ b/octavia/api/v2/controllers/member.py
@@ -557,7 +557,7 @@ class AllMembersController(MembersController):
                 pool_model.provisioning_status != constants.DELETED
                 ).distinct().all()
 
-            # check that at an LB has been found
+            # check that an LB has been found
             if len(lb_ids) < 1:
                 exc = exceptions.NotFound()
                 exc.msg = "No load balancer found for the provided pools."

--- a/octavia/api/v2/controllers/member.py
+++ b/octavia/api/v2/controllers/member.py
@@ -377,10 +377,12 @@ class MembersController(MemberController):
     def __init__(self, pool_id):
         super().__init__(pool_id)
 
-    @wsme_pecan.wsexpose(None, wtypes.text,
-                         body=member_types.MembersRootPUT, status_code=202)
-    def put(self, additive_only=False, members_=None):
-        """Updates all members."""
+    def _put(self, additive_only=False, members_=None, dispatch_driver=True):
+        """Inner put method used by both MembersController.put and
+        AllMembersController.put. This is needed due to the dispatch_driver
+        argument, which is not supposed to be exposed to the API. Therefore,
+        this function cannot be annotated with wsexpose.
+        """
         members = members_.members
         additive_only = strutils.bool_from_string(additive_only)
         context = pecan_request.context.get('octavia_context')
@@ -517,9 +519,101 @@ class MembersController(MemberController):
                         context.session, m.id,
                         provisioning_status=constants.PENDING_DELETE)
 
-            # Dispatch to the driver
+        # Dispatch to the driver
+        if dispatch_driver:
             LOG.info("Sending Pool %s batch member update to provider %s",
                      db_pool.id, driver.name)
             driver_utils.call_provider(
                 driver.name, driver.member_batch_update, db_pool.id,
                 provider_members)
+
+    @wsme_pecan.wsexpose(None, wtypes.text,
+                         body=member_types.MembersRootPUT, status_code=202)
+    def put(self, additive_only=False, members_=None):
+        """Updates all members of a pool."""
+        self._put(additive_only=additive_only, members_=members_, dispatch_driver=True)
+
+
+class AllMembersController(MembersController):
+
+    def __init__(self):
+        super().__init__(None)
+
+    @wsme_pecan.wsexpose(None, wtypes.text,
+                         body=member_types.CrossPoolMembersRootPUT, status_code=202)
+    def put(self, additive_only=False, members_=None):
+        """Updates all members across several pools."""
+        members = members_.members
+        context = pecan_request.context.get('octavia_context')
+        with context.session.begin():
+
+            # get the pools from the DB
+            pool_ids = set(m.pool_id for m in members)
+            # we cannot use self.repositories.pool.get_all, since it doesn't
+            # support filtering by multiple values (id='...' or id='...').
+            pool_model = self.repositories.pool.model_class
+            lb_ids = context.session.query(pool_model.load_balancer_id).filter(
+                pool_model.id.in_(pool_ids),
+                pool_model.provisioning_status != constants.DELETED
+                ).distinct().all()
+
+            # check that at an LB has been found
+            if len(lb_ids) < 1:
+                exc = exceptions.NotFound()
+                exc.msg = "No load balancer found for the provided pools."
+                raise exc
+
+            # check that the pools belong to one single LB and get its ID
+            if len(lb_ids) > 1:
+                raise exceptions.InvalidFilterArgument()
+            # ID is the first element of the first tuple
+            lb_id = lb_ids[0][0]
+
+            # baseline LB data for provider update call
+            db_lb = self._get_db_lb(context.session, lb_id, show_deleted=False)
+            old_provider_lb = (
+                driver_utils.db_loadbalancer_to_provider_loadbalancer(
+                    db_lb, for_delete=True))
+
+        # call MembersController._put for each pool.
+        some_pools_updated = False
+        for pool_id in pool_ids:
+
+            # since _put sets the pool's LB to PENDING_UPDATE, we need to
+            # reset it for the next pool, if we already updated a pool.
+            if some_pools_updated:
+                with context.session.begin():
+                    self.repositories.load_balancer.update(
+                        context.session, lb_id,
+                        provisioning_status=constants.ACTIVE)
+
+            # prepare body for regular batch member update
+            body = member_types.MembersRootPUT()
+            # Each element of the members list is a CrossPoolMemberPUT
+            # instance, which inherits from MemberPOST. The MembersController
+            # expects MemberPOST, so this works fine.
+            body.members = [m for m in members if m.pool_id == pool_id]
+
+            # run regular batch member update for this pool
+            # No need to instantiate the superclass, just call its __init__
+            # method (note that this sets self.pool_id)
+            super().__init__(pool_id)
+            super()._put(additive_only=additive_only, members_=body,
+                         dispatch_driver=False)
+            some_pools_updated = True
+
+        # updated LB data for provider update call
+        with context.session.begin():
+            db_lb = self._get_db_lb(context.session, lb_id, show_deleted=False)
+            new_provider_lb = (
+                driver_utils.db_loadbalancer_to_provider_loadbalancer(
+                    db_lb, for_delete=True))
+
+        # Dispatch to the provider
+        _, provider = self._get_lb_project_id_provider(context.session, lb_id)
+        driver = driver_factory.get_driver(provider)
+        LOG.info("Sending cross-pool batch member load balancer update to provider %s",
+                 driver.name)
+        driver_utils.call_provider(
+            driver.name, driver.loadbalancer_update,
+            old_provider_lb, new_provider_lb)

--- a/octavia/api/v2/controllers/pool.py
+++ b/octavia/api/v2/controllers/pool.py
@@ -549,12 +549,19 @@ class PoolsController(base.BaseController):
                                        provider_pool)
 
     @pecan_expose()
-    def _lookup(self, pool_id, *remainder):
+    def _lookup(self, path_segment, *remainder):
         """Overridden pecan _lookup method for custom routing.
 
         Verifies that the pool passed in the url exists, and if so decides
         which controller, if any, should control be passed.
         """
+
+        # cross-pool batch member update
+        if path_segment == 'members':
+            return member.AllMembersController(), remainder
+
+        # normal pool member update
+        pool_id = path_segment
         context = pecan_request.context.get('octavia_context')
         if pool_id and remainder and remainder[0] == 'members':
             remainder = remainder[1:]

--- a/octavia/api/v2/controllers/pool.py
+++ b/octavia/api/v2/controllers/pool.py
@@ -553,14 +553,14 @@ class PoolsController(base.BaseController):
         """Overridden pecan _lookup method for custom routing.
 
         Verifies that the pool passed in the url exists, and if so decides
-        which controller, if any, should control be passed.
+        to which controller, if any, should control be passed.
         """
 
         # cross-pool batch member update
         if path_segment == 'members':
             return member.AllMembersController(), remainder
 
-        # normal pool member update
+        # normal batch member update
         pool_id = path_segment
         context = pecan_request.context.get('octavia_context')
         if pool_id and remainder and remainder[0] == 'members':

--- a/octavia/api/v2/types/member.py
+++ b/octavia/api/v2/types/member.py
@@ -114,6 +114,17 @@ class MembersRootPUT(types.BaseType):
     members = wtypes.wsattr([MemberPOST])
 
 
+# This class needs to inherit from MemberPOST instead of MemberPUT (just like
+# MembersRootPUT is using MemberPOST), in order to allow address/port in the
+# payload for matching the member
+class CrossPoolMemberPUT(MemberPOST):
+    pool_id = wtypes.wsattr(wtypes.UuidType(), mandatory=True)
+
+
+class CrossPoolMembersRootPUT(types.BaseType):
+    members = wtypes.wsattr([CrossPoolMemberPUT])
+
+
 class MemberSingleCreate(BaseMemberType):
     """Defines mandatory and optional attributes of a POST request."""
     name = wtypes.wsattr(wtypes.StringType(max_length=255))

--- a/specs/version15.0/member-update-across-pools.rst
+++ b/specs/version15.0/member-update-across-pools.rst
@@ -1,0 +1,100 @@
+..
+ This work is licensed under a Creative Commons Attribution 3.0 Unported
+ License.
+
+ http://creativecommons.org/licenses/by/3.0/legalcode
+
+===========================================
+Support for pool member update across pools
+===========================================
+
+Allow updating pool members across multiple pools with a single update request
+(PUT).
+
+Problem description
+===================
+
+At SAP cloud infrastructure (and probably in other places), Octavia load
+balancers are often used to implement (Gardener) Kubernetes services; One
+listener-pool pair is created per service port, and one member per pool per K8s
+node.
+When the Kubernetes nodes are updated one after another, each node needs to be
+removed from the load balancer and then added again. This means node updates
+cause many LB updates, at least one for every pool member in every pool. This
+can mean hundreds of LB updates even when rolling the nodes only once. Each
+update means the client has to wait for the Octavia provider driver to sync the
+load balancer and set it to ACTIVE, before the next pool member can be updated.
+For hundreds of pool members this can accumulate to an update time of an hour or
+more.
+The amount of update requests can be reduced to one by implementing support for
+updating all pool members of a load balancer at the same time.
+
+Proposed change
+===============
+
+Add new endpoint for batch-updating members across several pools, similar to
+the existing endpoint for batch-updating members of a single pool.
+
+This new endpoint behaves like the member batch update endpoint, but affects
+members across several pools. It does *not* affect pools themselves, i.e.
+you cannot add/remove or update pools with this new endpoint, only pool
+members.
+
+
+Alternatives
+------------
+
+1. Updating the load balancer for every single pool member in every single pool,
+   for possibly hundred of pool members. As described above, this means waiting
+   for the provider driver to sync the LB after each update, accumulating a lot
+   of time, up to an hour or even more. This is the only current option.
+
+2. Introducing a custom update logic in the provider driver, independent of the
+   API, e. g. by sending one update per pool member, with a special flag (e. g.
+   a special tag) in the update request that marks it as preliminary, so that
+   the provider driver does not apply the update yet and instead sets the load
+   balancer's provisioning status back to `ACTIVE` to allow the client to send
+   more updates. Only when an update without the preliminary flag is received
+   does the provider driver actually set the load balancer' provisioning status
+   to `PENDING_UPDATE` and syncs the load balancer to the backend.
+   This approach is hacky, unintuitive, and depends on the provider driver in
+   use. Also, it does not reduce the amount of updates that need to be sent,
+   only the time needed to wait for each update.
+
+3. Use the existing "fully-populated load balancer" creation feature with a
+   special token (e. g. a special tag) that denotes that a load balancer with a
+   specified ID should be updated instead of creating a new one. This would also
+   have to be handled by the provider driver, which would have to delete the
+   load balancer database entry created by Octavia API, to then update the
+   intended load balancer instead. This approach is just as hacky and provider
+   driver dependent as the last one, but additionally introduces the possibility
+   of the request being rejected, e. g. due to missing quota, even though it's
+   not the intention to create a new load balancer.
+
+Data model impact
+-----------------
+
+This change requires no modification to the data model. Octavia updates DB
+entries for members just as it does with update requests to a single member and
+batch update requests to members of a given pool.
+
+REST API impact
+---------------
+
+This change adds new endpoint `/v2/lbaas/pools/members` for batch-updating
+members across several pools, similar to the existing
+`/v2/lbaas/pools/{pool_id}/members` `PUT` endpoint for batch-updating members
+of a single pool.
+
+The payload follows the same specification as the payload for the
+`/v2/lbaas/pools/{pool_id}/members` `PUT` endpoint, except that every member
+must include a `pool_id` field in order to identify which pool it belongs to.
+Pool members are matched by their pool_id/IP/port combination (similar to how
+the existing batch pool member update matches them by their IP/port
+combination).
+This means that - just like in the existing member batch update endpoint - pool
+members not specified in the payload will be deleted, unless `additive_only` is
+set to `true`.
+
+No new API resources are being implemented, only existing API resources are
+used.


### PR DESCRIPTION
Add new controller for cross-pool batch member update, which uses the existing batch member update controller (`MembersController`).

Separate out the existing batch member update into an inner function `_put`, which is called from both `MembersController.put`, as well as from the new `AllMembersController.put`.

Note that this is likely going to have to be refactored for performance and Openstack conventions once we upstream, so this is not final, but it's what works well for now for us.

---
Note that there is one minor divergence from the spec: Only pools specified in the request are updated. That is, the members from pools which don't have any members in the request are untouched. I think this behavior is preferable, so I'm going to adjust the spec accordingly before submitting an upstream request, depending on your view on this matter.