### PR TITLE
Fix issues related to pkg_resources module

### DIFF
--- a/octavia/common/utils.py
+++ b/octavia/common/utils.py
@@ -31,6 +31,7 @@ from oslo_utils import excutils
 from stevedore import driver as stevedore_driver
 
 from octavia.common import constants
+
 if typing.TYPE_CHECKING:
     from octavia.network import base as network_base
 

--- a/octavia/tests/common/sample_certs.py
+++ b/octavia/tests/common/sample_certs.py
@@ -15,7 +15,7 @@
 
 import base64
 
-import pkg_resources
+from importlib import resources
 
 
 X509_CERT_CN = 'www.example.com'
@@ -813,8 +813,11 @@ D7BF8MN1oUAOpyYqAjkGddSEuMyNmwtHKZI1dyQ0gBIQdiU9yAG2oTbUIK4msbBV
 uJIQ
 -----END CERTIFICATE-----"""
 
-PKCS12_BUNDLE = pkg_resources.resource_string(
-    'octavia.tests.unit.common.sample_configs', 'sample_pkcs12.p12')
+PKCS12_BUNDLE = (
+    resources.files('octavia.tests.unit.common.sample_configs')
+    .joinpath('sample_pkcs12.p12')
+    .read_bytes()
+)
 
 X509_CA_CERT_CN = 'ca.example.org'
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,8 +5,8 @@ hacking>=6.1.0,<6.2.0 # Apache-2.0
 requests-mock>=1.2.0 # Apache-2.0
 coverage!=4.4,>=4.0 # Apache-2.0
 fixtures>=3.0.0 # Apache-2.0/BSD
-flake8-import-order>=0.18.0,<0.19.0 # LGPLv3
 python-subunit>=1.0.0 # Apache-2.0/BSD
+flake8-import-order>=0.19.0 # LGPLv3
 oslotest>=3.2.0 # Apache-2.0
 pylint>=2.5.3 # GPLv2
 testrepository>=0.0.18 # Apache-2.0/BSD


### PR DESCRIPTION
This is a hotfix for the problem raised in internal CI:
```
root@94e28c1907b9:/opt/test/octavia# ./.tox/py3/bin/pip freeze | grep set
charset-normalizer==3.4.1
setproctitle==1.3.4
setuptools==82.0.0
root@94e28c1907b9:/opt/test/octavia# ./.tox/py3/bin/python
Python 3.12.10 (main, Apr  9 2025, 03:25:09) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pkg_resources
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'pkg_resources'
>>>
```

The problem is well-known and was fixed in upstream: https://github.com/openstack/octavia/commit/8ccea286e7619a73dba24086fc7a4eda9a97c7f7

So, we can cherry-pick this fix.