### PR TITLE
[hotfix] Remove lock for quotas checks.

### DIFF
--- a/octavia/db/repositories.py
+++ b/octavia/db/repositories.py
@@ -459,7 +459,6 @@ class Repositories:
         quotas = (session.query(models.Quotas)
                     .filter_by(project_id=project_id)
                     .populate_existing()
-                    .with_for_update()
                     .first())
         if _class == data_models.LoadBalancer:
             # Decide which quota to use


### PR DESCRIPTION
This hotfix is removing the `FOR UPDATE` option from `SELECT` queries for the quotas table. Because we have problems with lock timeouts in high-loaded regions.