### PR TITLE
Fix quota usage endpoint: Write-back not working

### DIFF
--- a/octavia/api/v2/controllers/base.py
+++ b/octavia/api/v2/controllers/base.py
@@ -232,7 +232,10 @@ class BaseController(pecan_rest.RestController):
         counted, and if not, recounts and updates usage in the database."""
 
         # At this point project_id should not ever be None or Unset
-        quotas = self.repositories.quotas.get(session, project_id=project_id)
+        quotas = (session.query(models.Quotas)
+                        .filter_by(project_id=project_id)
+                        .populate_existing()
+                        .first())
 
         loadbalancer = None
         listener = None


### PR DESCRIPTION
Since `self.repositories.quotas.get` returns a model object, assignments like e. g. `quotas.in_use_load_balancer = loadbalancer` don't write anything back to the DB. We need an SQLAlchemy ORM instance instead.

This fixes #61 